### PR TITLE
Fixed workstep duration saving in database

### DIFF
--- a/source/3dPrintCalculatorLibrary/Models/Calculation3d.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Calculation3d.cs
@@ -249,6 +249,11 @@ namespace AndreasReitberger.Models
         public List<Workstep> WorkSteps
         { get; set; } = new List<Workstep>();
 
+        //[ManyToMany(typeof(WorkstepDurationCalculation))]
+        [OneToMany]
+        public List<WorkstepDuration> WorkStepDurations
+        { get; set; } = new List<WorkstepDuration>();
+
         [Ignore]
         public ObservableCollection<CalculationAttribute> PrintTimes
         { get; set; } = new ObservableCollection<CalculationAttribute>();
@@ -807,6 +812,11 @@ namespace AndreasReitberger.Models
                     switch (ws.CalculationType)
                     {
                         case CalculationType.PerHour:
+                            WorkstepDuration workstepDuration = WorkStepDurations?.FirstOrDefault(wsd => wsd.WorkstepId == ws.Id);
+                            if(workstepDuration != null)
+                            {
+                                ws.Duration = workstepDuration.Duration;
+                            }
                             double totalPerHour = ws.TotalCosts;
                             //double totalPerHour = Convert.ToDouble(ws.Duration) * Convert.ToDouble(ws.Price);
                             Costs.Add(new CalculationAttribute()

--- a/source/3dPrintCalculatorLibrary/Models/Material3d.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Material3d.cs
@@ -27,9 +27,11 @@ namespace AndreasReitberger.Models
         [ForeignKey(typeof(Calculation3d))]
         public Guid CalculationId
         { get; set; }
+        /*
         [ManyToOne]
-        public Calculation3d Calculation
+        public Calculation3d Calculation      
         { get; set; }
+        */
         public string Name
         { get; set; } = string.Empty;
         public string SKU

--- a/source/3dPrintCalculatorLibrary/Models/WorkstepAdditions/WorkstepDuration.cs
+++ b/source/3dPrintCalculatorLibrary/Models/WorkstepAdditions/WorkstepDuration.cs
@@ -1,0 +1,53 @@
+﻿using SQLite;
+using SQLiteNetExtensions.Attributes;
+using System;
+
+namespace AndreasReitberger.Models.WorkstepAdditions
+{
+    [Table("WorkstepDurations")]
+    public class WorkstepDuration
+    {
+        #region Properties
+        [PrimaryKey]
+        public Guid Id
+        { get; set; }
+
+        [ForeignKey(typeof(Calculation3d))]
+        public Guid CalculationId
+        { get; set; }
+
+        [ManyToOne]
+        public Calculation3d Calculation { get; set; }
+
+        public Guid WorkstepId
+        { get; set; }
+
+        public double Duration
+        { get; set; } = 0;
+        #endregion
+
+        #region Constructors
+        public WorkstepDuration()
+        {
+            Id = Guid.NewGuid();
+        }
+        #endregion
+
+        #region Overrides
+        public override string ToString()
+        {
+            return Duration.ToString();
+        }
+        public override bool Equals(object obj)
+        {
+            if (obj is not WorkstepDuration item)
+                return false;
+            return Id.Equals(item.Id);
+        }
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+        #endregion
+    }
+}

--- a/source/3dPrintCalculatorLibrary/Models/WorkstepAdditions/WorkstepDurationCalculation.cs
+++ b/source/3dPrintCalculatorLibrary/Models/WorkstepAdditions/WorkstepDurationCalculation.cs
@@ -1,0 +1,14 @@
+﻿using SQLiteNetExtensions.Attributes;
+using System;
+
+namespace AndreasReitberger.Models.WorkstepAdditions
+{
+    public class WorkstepDurationCalculation
+    {
+        [ForeignKey(typeof(WorkstepDuration))]
+        public Guid WorkstepDurationId { get; set; }
+
+        [ForeignKey(typeof(Calculation3d))]
+        public Guid CalculationId { get; set; }
+    }
+}


### PR DESCRIPTION
The set hours for hour-based `WorkStep`'s haven't been saved to the database.
This caused, that the price of the calculation has changed once the `Calculation3d` was loaded from the database.