### PR TITLE
Set `UseFixedHourlyMachineRate` obsolete

### DIFF
--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Printer3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Printer3d.cs
@@ -83,24 +83,9 @@ namespace AndreasReitberger.Print3d.SQLite
         [ObservableProperty]
         [property: JsonIgnore]
         double height = 1;
-        /*
-        [JsonIgnore, XmlIgnore]
-        public Guid BuildVolumeId { get; set; }
 
-        [JsonProperty(nameof(BuildVolume))]
-        BuildVolume _buildVolume = new(0, 0, 0);
-        [JsonIgnore, Ignore]
-        //[ManyToOne(nameof(BuildVolumeId))]
-        [Obsolete("Use the x,y,z properties instead")]
-        public BuildVolume BuildVolume
-        {
-            get { return _buildVolume; }
-            set { SetProperty(ref _buildVolume, value); }
-        }
-        */
-
-        [ObservableProperty]
-        [property: JsonIgnore]
+        [ObservableProperty, Obsolete("No longer supported, assign a `HourlyMachineRate` instead.")]
+        [property: JsonIgnore, Obsolete("No longer supported, assign a `HourlyMachineRate` instead.")]
         bool useFixedMachineHourRating = false;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary/Interfaces/IPrinter3d.cs
+++ b/source/3dPrintCalculatorLibrary/Interfaces/IPrinter3d.cs
@@ -21,7 +21,7 @@ namespace AndreasReitberger.Print3d.Interfaces
         public double Width { get; set; }
         public double Depth { get; set; }
         public double Height { get; set; }
-        public bool UseFixedMachineHourRating { get; set; }
+        //public bool UseFixedMachineHourRating { get; set; }
         public Guid HourlyMachineRateId { get; set; }
         //public IHourlyMachineRate HourlyMachineRate { get; set; }
         public Guid SlicerConfigId { get; set; }

--- a/source/3dPrintCalculatorLibrary/Models/Printer3d.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Printer3d.cs
@@ -91,8 +91,8 @@ namespace AndreasReitberger.Print3d.Models
         }
         */
 
-        [ObservableProperty]
-        [property: JsonIgnore]
+        [ObservableProperty, Obsolete("No longer supported, assign a `HourlyMachineRate` instead.")]
+        [property: JsonIgnore, Obsolete("No longer supported, assign a `HourlyMachineRate` instead.")]
         bool useFixedMachineHourRating = false;
 
         [ObservableProperty]


### PR DESCRIPTION
This PR removes the ability to set a fixed machine rate due to complicates with database saving. It's recommended to just create a `HourlyMachineRate` and assign it to the `Printer3d` instead.