### PR TITLE
Added `CalculationAttributeItem` to define `FaileRate`

### DIFF
--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3d.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3d.Extensions.cs
@@ -25,6 +25,8 @@ namespace AndreasReitberger.Print3d.SQLite
                 {
                     Attribute = file.FileName,
                     Value = printTime,
+                    Type = CalculationAttributeType.Machine,
+                    Item = CalculationAttributeItem.Default,
                     FileId = file.Id,
                     FileName = file.FileName,
                 });
@@ -48,6 +50,8 @@ namespace AndreasReitberger.Print3d.SQLite
                     PrintTimes?.Add(new CalculationAttribute()
                     {
                         Attribute = $"{file.FileName}_FailRate",
+                        Type = CalculationAttributeType.Machine,
+                        Item = CalculationAttributeItem.FailRate,
                         Value = printTime * FailRate / 100,
                         FileId = file.Id,
                         FileName = file.FileName,
@@ -79,6 +83,7 @@ namespace AndreasReitberger.Print3d.SQLite
                         Attribute = Material.Name,
                         Value = _material,
                         Type = CalculationAttributeType.Material,
+                        Item = CalculationAttributeItem.Default,
                         FileId = file.Id,
                         FileName = file.FileName,
                     });
@@ -89,6 +94,7 @@ namespace AndreasReitberger.Print3d.SQLite
                             Attribute = $"{Material.Name}_FailRate",
                             Value = _material * FailRate / 100,
                             Type = CalculationAttributeType.Material,
+                            Item = CalculationAttributeItem.FailRate,
                             FileId = file.Id,
                             FileName = file.FileName,
                         });
@@ -119,8 +125,8 @@ namespace AndreasReitberger.Print3d.SQLite
                                         if (materialPrintObject != null)
                                         {
                                             double refreshedMaterial = (powderInBuildArea -
-                                                (materialPrintObject.Value * material.FactorLToKg / UnitFactor.GetUnitFactor(Unit.Kilogramm))) * refreshRatio.Value / 100f;
-                                            refreshed = (refreshedMaterial / material.FactorLToKg * UnitFactor.GetUnitFactor(Unit.Kilogramm));
+                                                (materialPrintObject.Value * material.FactorLToKg / UnitFactor.GetUnitFactor(Unit.Kilogram))) * refreshRatio.Value / 100f;
+                                            refreshed = (refreshedMaterial / material.FactorLToKg * UnitFactor.GetUnitFactor(Unit.Kilogram));
                                         }
                                         else
                                             refreshed = 0;
@@ -139,8 +145,9 @@ namespace AndreasReitberger.Print3d.SQLite
                             OverallMaterialCosts.Add(new CalculationAttribute()
                             {
                                 LinkedId = material.Id,
-                                Attribute = material.Name,
+                                Attribute = materialUsage.Attribute,
                                 Type = CalculationAttributeType.Material,
+                                Item = materialUsage.Item,
                                 Value = totalCosts,
                                 FileId = materialUsage.FileId,
                                 FileName = materialUsage.FileName,
@@ -156,6 +163,7 @@ namespace AndreasReitberger.Print3d.SQLite
                                 LinkedId = material.Id,
                                 Attribute = $"{material.Name} (Refreshed)",
                                 Type = CalculationAttributeType.Material,
+                                Item = CalculationAttributeItem.PowderRefresh,
                                 Value = refreshCosts,
                                 FileId = file.Id,
                                 FileName = file.FileName,
@@ -185,6 +193,7 @@ namespace AndreasReitberger.Print3d.SQLite
                                         LinkedId = printer.Id,
                                         Attribute = printer.Name,
                                         Type = CalculationAttributeType.Machine,
+                                        Item = pt.Item,
                                         Value = machineHourRate,
                                         FileId = pt.FileId,
                                         FileName = pt.FileName,
@@ -203,6 +212,7 @@ namespace AndreasReitberger.Print3d.SQLite
                                         LinkedId = printer.Id,
                                         Attribute = printer.Name,
                                         Type = CalculationAttributeType.Energy,
+                                        Item = pt.Item,
                                         Value = totalEnergyCost,
                                         FileId = pt.FileId,
                                         FileName = pt.FileName,

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/CalculationAdditions/CalculationAttribute.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/CalculationAdditions/CalculationAttribute.cs
@@ -37,6 +37,9 @@ namespace AndreasReitberger.Print3d.SQLite.CalculationAdditions
         CalculationAttributeType type;
 
         [ObservableProperty]
+        CalculationAttributeItem item = CalculationAttributeItem.Default;
+
+        [ObservableProperty]
         double value;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/File3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/File3d.cs
@@ -40,7 +40,7 @@ namespace AndreasReitberger.Print3d.SQLite
 
         [ObservableProperty]
         [property: ManyToOne(nameof(ModelWeightId))]
-        ModelWeight weight = new(-1, Enums.Unit.Gramm);
+        ModelWeight weight = new(-1, Enums.Unit.Gram);
 
         [ObservableProperty]
         double printTime = 0;

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/FileAdditions/ModelWeight.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/FileAdditions/ModelWeight.cs
@@ -31,7 +31,7 @@ namespace AndreasReitberger.Print3d.SQLite.FileAdditions
         }
 
         [ObservableProperty]
-        Unit unit = Unit.Gramm;
+        Unit unit = Unit.Gram;
         partial void OnUnitChanged(Unit value)
         {
             RecalculateWeightInGramm = true;

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Material3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Material3d.cs
@@ -35,7 +35,7 @@ namespace AndreasReitberger.Print3d.SQLite
         string sKU = string.Empty;
 
         [ObservableProperty]
-        Unit unit = Unit.Kilogramm;
+        Unit unit = Unit.Kilogram;
 
         [ObservableProperty]
         double packageSize = 1;
@@ -101,7 +101,7 @@ namespace AndreasReitberger.Print3d.SQLite
         string technicalDatasheet = string.Empty;
 
         [ObservableProperty]
-        Unit spoolWeightUnit = Unit.Gramm;
+        Unit spoolWeightUnit = Unit.Gram;
 
         [ObservableProperty]
         double spoolWeight = 200;

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Storage3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Storage3d.cs
@@ -34,7 +34,7 @@ namespace AndreasReitberger.Print3d.SQLite
 
         #region Methods
 
-        public Storage3dItem CreateStockItem(Material3d material, double amount = 0, Unit unit = Unit.Kilogramm)
+        public Storage3dItem CreateStockItem(Material3d material, double amount = 0, Unit unit = Unit.Kilogram)
         {
             Storage3dItem item = new() { Material = material };
             if (amount != 0) UpdateStockAmount(item, amount, unit);
@@ -140,7 +140,7 @@ namespace AndreasReitberger.Print3d.SQLite
             else return null;
         }
 
-        public bool UpdateStockAmount(Storage3dItem item, double amount, Unit unit = Unit.Kilogramm)
+        public bool UpdateStockAmount(Storage3dItem item, double amount, Unit unit = Unit.Kilogram)
         {
             if (amount > 0)
             {

--- a/source/3dPrintCalculatorLibrary.SQLite/PrintCalculator3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/PrintCalculator3d.cs
@@ -18,6 +18,7 @@ namespace AndreasReitberger.Print3d.SQLite
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
@@ -32,6 +33,7 @@ namespace AndreasReitberger.Print3d.SQLite
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
@@ -52,6 +54,7 @@ namespace AndreasReitberger.Print3d.SQLite
                     Name = calculation.DifferFileCosts ? $"{cost.Attribute} ({cost.FileName})" : cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
@@ -70,6 +73,7 @@ namespace AndreasReitberger.Print3d.SQLite
                     Name = calculation.DifferFileCosts ? $"{cost.Attribute} ({cost.FileName})" : cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
@@ -87,6 +91,7 @@ namespace AndreasReitberger.Print3d.SQLite
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
@@ -102,6 +107,7 @@ namespace AndreasReitberger.Print3d.SQLite
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
@@ -117,6 +123,7 @@ namespace AndreasReitberger.Print3d.SQLite
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));

--- a/source/3dPrintCalculatorLibrary/Enums/CalculationAttributeItem.cs
+++ b/source/3dPrintCalculatorLibrary/Enums/CalculationAttributeItem.cs
@@ -1,0 +1,11 @@
+﻿namespace AndreasReitberger.Print3d.Enums
+{
+    public enum CalculationAttributeItem
+    {
+        Default,
+        FailRate,
+        Tax,
+        Margin,
+        PowderRefresh,
+    }
+}

--- a/source/3dPrintCalculatorLibrary/Enums/CalculationAttributeTarget.cs
+++ b/source/3dPrintCalculatorLibrary/Enums/CalculationAttributeTarget.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace AndreasReitberger.Print3d.Enums
+﻿namespace AndreasReitberger.Print3d.Enums
 {
     public enum CalculationAttributeTarget
     {

--- a/source/3dPrintCalculatorLibrary/Enums/Unit3d.cs
+++ b/source/3dPrintCalculatorLibrary/Enums/Unit3d.cs
@@ -4,8 +4,8 @@ namespace AndreasReitberger.Print3d.Enums
 {
     public enum Unit
     {
-        Gramm,
-        Kilogramm,
+        Gram,
+        Kilogram,
         MetricTons,
         Mililiters,
         Liters,

--- a/source/3dPrintCalculatorLibrary/Interfaces/ICalculationAttribute.cs
+++ b/source/3dPrintCalculatorLibrary/Interfaces/ICalculationAttribute.cs
@@ -13,6 +13,7 @@ namespace AndreasReitberger.Print3d.Interfaces
         public Guid LinkedId { get; set; }
         public string Attribute { get; set; }
         public CalculationAttributeType Type { get; set; }
+        public CalculationAttributeItem Item { get; set; }
         public double Value { get; set; }
         public bool IsPercentageValue { get; set; }
         public bool SkipForCalculation { get; set; }

--- a/source/3dPrintCalculatorLibrary/Models/Calculation3d.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Calculation3d.Extensions.cs
@@ -29,6 +29,8 @@ namespace AndreasReitberger.Print3d.Models
                 {
                     Attribute = file.FileName,
                     Value = printTime,
+                    Type = CalculationAttributeType.Machine,
+                    Item = CalculationAttributeItem.Default,
                     FileId = file.Id,
                     FileName = file.FileName,
                 });
@@ -53,6 +55,8 @@ namespace AndreasReitberger.Print3d.Models
                     {
                         Attribute = $"{file.FileName}_FailRate",
                         Value = printTime * FailRate / 100,
+                        Type = CalculationAttributeType.Machine,
+                        Item = CalculationAttributeItem.FailRate,
                         FileId = file.Id,
                         FileName = file.FileName,
                     });
@@ -83,6 +87,7 @@ namespace AndreasReitberger.Print3d.Models
                         Attribute = Material.Name,
                         Value = _material,
                         Type = CalculationAttributeType.Material,
+                        Item = CalculationAttributeItem.FailRate,
                         FileId = file.Id,
                         FileName = file.FileName,
                     });
@@ -93,6 +98,7 @@ namespace AndreasReitberger.Print3d.Models
                             Attribute = $"{Material.Name}_FailRate",
                             Value = _material * FailRate / 100,
                             Type = CalculationAttributeType.Material,
+                            Item = CalculationAttributeItem.FailRate,
                             FileId = file.Id,
                             FileName = file.FileName,
                         });
@@ -123,8 +129,8 @@ namespace AndreasReitberger.Print3d.Models
                                         if (materialPrintObject != null)
                                         {
                                             double refreshedMaterial = (powderInBuildArea -
-                                                (materialPrintObject.Value * material.FactorLToKg / UnitFactor.GetUnitFactor(Unit.Kilogramm))) * refreshRatio.Value / 100f;
-                                            refreshed = (refreshedMaterial / material.FactorLToKg * UnitFactor.GetUnitFactor(Unit.Kilogramm));
+                                                (materialPrintObject.Value * material.FactorLToKg / UnitFactor.GetUnitFactor(Unit.Kilogram))) * refreshRatio.Value / 100f;
+                                            refreshed = (refreshedMaterial / material.FactorLToKg * UnitFactor.GetUnitFactor(Unit.Kilogram));
                                         }
                                         else
                                             refreshed = 0;
@@ -145,6 +151,7 @@ namespace AndreasReitberger.Print3d.Models
                                 LinkedId = material.Id,
                                 Attribute = material.Name,
                                 Type = CalculationAttributeType.Material,
+                                Item = materialUsage.Item,
                                 Value = totalCosts,
                                 FileId = materialUsage.FileId,
                                 FileName = materialUsage.FileName,
@@ -160,6 +167,7 @@ namespace AndreasReitberger.Print3d.Models
                                 LinkedId = material.Id,
                                 Attribute = $"{material.Name} (Refreshed)",
                                 Type = CalculationAttributeType.Material,
+                                Item = CalculationAttributeItem.PowderRefresh,
                                 Value = refreshCosts,
                                 FileId = file.Id,
                                 FileName = file.FileName,
@@ -189,6 +197,7 @@ namespace AndreasReitberger.Print3d.Models
                                         LinkedId = printer.Id,
                                         Attribute = printer.Name,
                                         Type = CalculationAttributeType.Machine,
+                                        Item = pt.Item,
                                         Value = machineHourRate,
                                         FileId = pt.FileId,
                                         FileName = pt.FileName,
@@ -207,6 +216,7 @@ namespace AndreasReitberger.Print3d.Models
                                         LinkedId = printer.Id,
                                         Attribute = printer.Name,
                                         Type = CalculationAttributeType.Energy,
+                                        Item = pt.Item,
                                         Value = totalEnergyCost,
                                         FileId = pt.FileId,
                                         FileName = pt.FileName,

--- a/source/3dPrintCalculatorLibrary/Models/CalculationAdditions/CalculationAttribute.cs
+++ b/source/3dPrintCalculatorLibrary/Models/CalculationAdditions/CalculationAttribute.cs
@@ -32,6 +32,9 @@ namespace AndreasReitberger.Print3d.Models.CalculationAdditions
         CalculationAttributeType type;
 
         [ObservableProperty]
+        CalculationAttributeItem item = CalculationAttributeItem.Default;
+
+        [ObservableProperty]
         double value;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary/Models/File3d.cs
+++ b/source/3dPrintCalculatorLibrary/Models/File3d.cs
@@ -36,7 +36,7 @@ namespace AndreasReitberger.Print3d.Models
         Guid modelWeightId;
 
         [ObservableProperty]
-        ModelWeight weight = new(-1, Enums.Unit.Gramm);
+        ModelWeight weight = new(-1, Enums.Unit.Gram);
 
         [ObservableProperty]
         double printTime = 0;

--- a/source/3dPrintCalculatorLibrary/Models/FileAdditions/ModelWeight.cs
+++ b/source/3dPrintCalculatorLibrary/Models/FileAdditions/ModelWeight.cs
@@ -27,7 +27,7 @@ namespace AndreasReitberger.Print3d.Models.FileAdditions
         }
 
         [ObservableProperty]
-        Unit unit = Unit.Gramm;
+        Unit unit = Unit.Gram;
         partial void OnUnitChanged(Unit value)
         {
             RecalculateWeightInGramm = true;

--- a/source/3dPrintCalculatorLibrary/Models/Material3d.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Material3d.cs
@@ -30,7 +30,7 @@ namespace AndreasReitberger.Print3d.Models
         string sKU = string.Empty;
 
         [ObservableProperty]
-        Unit unit = Unit.Kilogramm;
+        Unit unit = Unit.Kilogram;
 
         [ObservableProperty]
         double packageSize = 1;
@@ -90,7 +90,7 @@ namespace AndreasReitberger.Print3d.Models
         string technicalDatasheet = string.Empty;
 
         [ObservableProperty]
-        Unit spoolWeightUnit = Unit.Gramm;
+        Unit spoolWeightUnit = Unit.Gram;
 
         [ObservableProperty]
         double spoolWeight = 200;

--- a/source/3dPrintCalculatorLibrary/Models/Storage3d.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Storage3d.cs
@@ -32,7 +32,7 @@ namespace AndreasReitberger.Print3d.Models
 
         #region Methods
 
-        public Storage3dItem CreateStockItem(Material3d material, double amount = 0, Unit unit = Unit.Kilogramm)
+        public Storage3dItem CreateStockItem(Material3d material, double amount = 0, Unit unit = Unit.Kilogram)
         {
             Storage3dItem item = new() { Material = material };
             if (amount != 0) UpdateStockAmount(item, amount, unit);
@@ -138,7 +138,7 @@ namespace AndreasReitberger.Print3d.Models
             else return null;
         }
 
-        public bool UpdateStockAmount(Storage3dItem item, double amount, Unit unit = Unit.Kilogramm)
+        public bool UpdateStockAmount(Storage3dItem item, double amount, Unit unit = Unit.Kilogram)
         {
             if (amount > 0)
             {

--- a/source/3dPrintCalculatorLibrary/PrintCalculator3d.cs
+++ b/source/3dPrintCalculatorLibrary/PrintCalculator3d.cs
@@ -18,6 +18,7 @@ namespace AndreasReitberger.Print3d
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
@@ -32,6 +33,7 @@ namespace AndreasReitberger.Print3d
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
@@ -52,6 +54,7 @@ namespace AndreasReitberger.Print3d
                     Name = calculation.DifferFileCosts ? $"{cost.Attribute} ({cost.FileName})" : cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
@@ -70,6 +73,7 @@ namespace AndreasReitberger.Print3d
                     Name = calculation.DifferFileCosts ? $"{cost.Attribute} ({cost.FileName})" : cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
@@ -87,6 +91,7 @@ namespace AndreasReitberger.Print3d
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
@@ -102,6 +107,7 @@ namespace AndreasReitberger.Print3d
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
@@ -117,6 +123,7 @@ namespace AndreasReitberger.Print3d
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));

--- a/source/3dPrintCalculatorLibrary/Utilities/Calculation3dChartItem.cs
+++ b/source/3dPrintCalculatorLibrary/Utilities/Calculation3dChartItem.cs
@@ -9,6 +9,7 @@ namespace AndreasReitberger.Print3d.Utilities
         public string Name { get; set; }
         public double Value { get; set; }
         public CalculationAttributeType AttributeType { get; set; }
+        public CalculationAttributeItem AttributeItem { get; set; }
         public Guid FileId { get; set; }
         public string FileName { get; set; }
         #endregion

--- a/source/3dPrintCalculatorLibrary/Utilities/UnitFactor.cs
+++ b/source/3dPrintCalculatorLibrary/Utilities/UnitFactor.cs
@@ -7,8 +7,8 @@ namespace AndreasReitberger.Print3d.Utilities
     {
         public static Dictionary<Unit, int> UnitFactors = new()
         {
-            { Unit.Gramm, 1 },
-            { Unit.Kilogramm, 1000 },
+            { Unit.Gram, 1 },
+            { Unit.Kilogram, 1000 },
             { Unit.MetricTons, 1000 * 1000 },
             { Unit.Mililiters, 1 },
             { Unit.Liters, 1000 },


### PR DESCRIPTION
This PR introduces a new enum `CalculationAttributeItem`, so that the `CalculationAttribute` can be defined as FailRate or not. Also fixed a type in `Gram` and `Kilogram`.

Fixed #30