### PR TITLE
Fixed calculation issues in `GetTotalCosts()`

### DIFF
--- a/common.props
+++ b/common.props
@@ -1,7 +1,7 @@
 
 <Project>
     <PropertyGroup>
-        <Version>1.2.0</Version>
+        <Version>1.2.1</Version>
         <!--<PackageIcon>logo_128.png</PackageIcon>-->
         <NeutralLanguage>en</NeutralLanguage>
 		<PackageProjectUrl>https://github.com/AndreasReitberger/3dPrintCostCalculatorSharp</PackageProjectUrl>

--- a/source/3dPrintCalculatorLibrary/Models/Calculation3d.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Calculation3d.Extensions.cs
@@ -514,14 +514,15 @@ namespace AndreasReitberger.Print3d.Models
                         Costs :
                         Costs
                             .Where(cost => cost.Type == calculationAttributeType))
-                        .Select(value => Convert.ToDouble(value.Value))
+                            .Select(value => Convert.ToDouble(value.Value))
                     : (calculationAttributeType == CalculationAttributeType.All ?
                         Costs
                             .Where(cost => cost.FileId == fileId) :
                         Costs
                             .Where(cost => cost.Type == calculationAttributeType && cost.FileId == fileId))
-                        .Select(value => Convert.ToDouble(value.Value));
+                            .Select(value => Convert.ToDouble(value.Value));
 
+                /*
                 IEnumerable<double> costsMachine = fileId == Guid.Empty
                    ? OverallPrinterCosts
                        .Where(cost =>
@@ -534,6 +535,75 @@ namespace AndreasReitberger.Print3d.Models
                             cost.LinkedId == Printer.Id) && cost.FileId == fileId)
                        .Select(value => Convert.ToDouble(value.Value))
                     ;
+                */
+                IEnumerable<double> costsMachine = fileId == Guid.Empty
+                    // If file id is empty
+                    // If all types are requested
+                    ? (calculationAttributeType == CalculationAttributeType.All ?
+                        OverallPrinterCosts
+                            .Where(cost =>
+                                cost.Attribute == Printer.Name ||
+                                cost.LinkedId == Printer.Id)
+                        :
+                        // If a specific type is requested
+                        OverallPrinterCosts
+                            .Where(cost =>
+                                cost.Type == calculationAttributeType &&
+                                (cost.Attribute == Printer.Name ||
+                                cost.LinkedId == Printer.Id)))
+                            .Select(value => Convert.ToDouble(value.Value))
+                    // If file id is not empty
+                    // If all types are requested
+                    : (calculationAttributeType == CalculationAttributeType.All ?
+                        OverallPrinterCosts
+                            .Where(cost =>
+                            cost.FileId == fileId &&
+                            (cost.Attribute == Printer.Name ||
+                            cost.LinkedId == Printer.Id))
+
+                        // If a specific type is requested
+                        :
+                        OverallPrinterCosts
+                            .Where(cost =>
+                            cost.Type == calculationAttributeType && cost.FileId == fileId &&
+                            (cost.Attribute == Printer.Name || cost.LinkedId == Printer.Id)
+                            ))
+                    .Select(value => Convert.ToDouble(value.Value));
+
+                IEnumerable<double> costsMaterial = fileId == Guid.Empty
+                   // If file id is empty
+                   // If all types are requested
+                   ? (calculationAttributeType == CalculationAttributeType.All ?
+                        OverallMaterialCosts
+                            .Where(cost =>
+                                cost.Attribute == Material.Name ||
+                                (CombineMaterialCosts || (cost.LinkedId == Material.Id)))
+                        :
+                        // If a specific type is requested
+                        OverallMaterialCosts
+                            .Where(cost =>
+                                cost.Type == calculationAttributeType && (
+                                cost.Attribute == Material.Name ||
+                                (CombineMaterialCosts || (cost.LinkedId == Material.Id)))))
+                            .Select(value => Convert.ToDouble(value.Value))
+                    // If file id is not empty
+                    // If all types are requested
+                    : (calculationAttributeType == CalculationAttributeType.All ?
+                        OverallMaterialCosts
+                            .Where(cost =>
+                            cost.FileId == fileId &&
+                            (cost.Attribute == Material.Name ||
+                            (CombineMaterialCosts || (cost.LinkedId == Material.Id))))
+
+                        // If a specific type is requested
+                        :
+                        OverallMaterialCosts
+                            .Where(cost =>
+                            cost.Type == calculationAttributeType && cost.FileId == fileId &&
+                            (cost.Attribute == Material.Name ||
+                            (CombineMaterialCosts || (cost.LinkedId == Material.Id)))))
+                    .Select(value => Convert.ToDouble(value.Value));
+                /*
                 IEnumerable<double> costsMaterial = fileId == Guid.Empty
                     ? OverallMaterialCosts
                         .Where(cost =>
@@ -545,10 +615,16 @@ namespace AndreasReitberger.Print3d.Models
                             (cost.Attribute == Material.Name ||
                             (CombineMaterialCosts || (cost.LinkedId == Material.Id))) && cost.FileId == fileId)
                         .Select(value => Convert.ToDouble(value.Value));
+                */
 
                 double total = 0;
                 foreach (var cost in costs)
                     total += cost;
+                foreach (var cost in costsMachine)
+                    total += cost;
+                foreach (var cost in costsMaterial)
+                    total += cost;
+                /*
                 if (calculationAttributeType == CalculationAttributeType.Machine || calculationAttributeType == CalculationAttributeType.All)
                 {
                     foreach (var cost in costsMachine)
@@ -559,6 +635,7 @@ namespace AndreasReitberger.Print3d.Models
                     foreach (var cost in costsMaterial)
                         total += cost;
                 }
+                */
                 return total;
             }
             catch (Exception)


### PR DESCRIPTION
If a specific `CalculationAttributeType` was requested, the method could return 0 even if the attribute are available in the costs. Also bumped version to 1.2.1

Fixed #34