### PR TITLE
Updated `CalculationAttribtue`

### DIFF
--- a/source/3dPrintCalculatorLibrary.SQLite/Models/CalculationAdditions/CalculationAttribute.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/CalculationAdditions/CalculationAttribute.cs
@@ -46,7 +46,13 @@ namespace AndreasReitberger.Print3d.SQLite.CalculationAdditions
         bool isPercentageValue = false;
 
         [ObservableProperty]
+        bool applyPerFile = false;
+
+        [ObservableProperty]
         bool skipForCalculation = false;
+
+        [ObservableProperty]
+        bool skipForMargin = false;
         #endregion
 
         #region Constructor

--- a/source/3dPrintCalculatorLibrary/Interfaces/ICalculationAttribute.cs
+++ b/source/3dPrintCalculatorLibrary/Interfaces/ICalculationAttribute.cs
@@ -16,7 +16,9 @@ namespace AndreasReitberger.Print3d.Interfaces
         public CalculationAttributeItem Item { get; set; }
         public double Value { get; set; }
         public bool IsPercentageValue { get; set; }
+        public bool ApplyPerFile { get; set; }
         public bool SkipForCalculation { get; set; }
+        public bool SkipForMargin { get; set; }
         #endregion
     }
 }

--- a/source/3dPrintCalculatorLibrary/Models/CalculationAdditions/CalculationAttribute.cs
+++ b/source/3dPrintCalculatorLibrary/Models/CalculationAdditions/CalculationAttribute.cs
@@ -41,7 +41,13 @@ namespace AndreasReitberger.Print3d.Models.CalculationAdditions
         bool isPercentageValue = false;
 
         [ObservableProperty]
+        bool applyPerFile = false;
+
+        [ObservableProperty]
         bool skipForCalculation = false;
+
+        [ObservableProperty]
+        bool skipForMargin = false;
         #endregion
 
         #region Constructor


### PR DESCRIPTION
This commit updates the `CalculationAttribtue` and adds two more properties to skip the element for margin calculation and to define, if the element is applied to each file or only once.

Fixed #37