### PR TITLE
Started to adjust `Calculation3dProfile` to hold lists

### DIFF
--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
@@ -313,8 +313,27 @@ namespace AndreasReitberger.NUnitTest
                     MultiplyPrintTimeWithQuantity = false
                 };
 
+                Item3d item = new()
+                {
+                    Name = "Nuts M3",
+                    PackageSize = 100,
+                    PackagePrice = 9.99d,
+                    Manufacturer = new()
+                    {
+                        Name = "Würth"
+                    },
+                    SKU = "2302423-1223"
+                };
+                Item3dUsage usage = new()
+                {
+                    Item = item,
+                    Quantity = 30,
+                    LinkedToFile = false,
+                };
+
                 _calculation = new();
                 // Add data
+                _calculation.AdditionalItems.Add(usage);
                 _calculation.Files.Add(file);
                 _calculation.Files.Add(file2);
                 _calculation.Printers.Add(printer);
@@ -349,6 +368,7 @@ namespace AndreasReitberger.NUnitTest
                     _calculation.MaterialCosts,
                     _calculation.CalculatedMargin,
                     _calculation.CalculatedTax,
+                    _calculation.ItemsCosts,
                 };
                 double summedCalc = costsCalc.Sum();
                 Assert.IsTrue(Math.Round(summedCalc, 2) == Math.Round(_calculation.TotalCosts, 2));
@@ -365,6 +385,7 @@ namespace AndreasReitberger.NUnitTest
                     _calculation2.MaterialCosts,
                     _calculation2.CalculatedMargin,
                     _calculation2.CalculatedTax,
+                    _calculation2.ItemsCosts,
                 };
                 summedCalc = costsCalc.Sum();
                 Assert.IsTrue(Math.Round(summedCalc, 2) == Math.Round(_calculation2.TotalCosts, 2));
@@ -854,8 +875,27 @@ namespace AndreasReitberger.NUnitTest
                 MultiplyPrintTimeWithQuantity = false
             };
 
+            Item3d item = new()
+            {
+                Name = "Nuts M3",
+                PackageSize = 100,
+                PackagePrice = 9.99d,
+                Manufacturer = new()
+                {
+                    Name = "Würth"
+                },
+                SKU = "2302423-1223"
+            };
+            Item3dUsage usage = new()
+            {
+                Item = item,
+                Quantity = 30,
+                LinkedToFile = false,
+            };
+
             _calculation = new Calculation3d();
             // Add data
+            _calculation.AdditionalItems.Add(usage);
             _calculation.Files.Add(file);
             _calculation.Files.Add(file2);
             _calculation.Printers.Add(printer);
@@ -927,6 +967,7 @@ namespace AndreasReitberger.NUnitTest
                     Description = "Take the costs for the resin tank replacement into account?",
                     Enabled = true,
                     TargetFamily = Material3dFamily.Resin,
+                    Target = ProcedureAdditionTarget.Machine,
                 };
                 resinTank.Parameters.Add(                  
                     new ProcedureCalculationParameter()
@@ -934,11 +975,11 @@ namespace AndreasReitberger.NUnitTest
                         Name = "Tank replacement costs",
                         Type = ProcedureCalculationType.ReplacementCosts,
                         Price = 50,
-                        WearFactor = 1000,
+                        WearFactor = 1,
                         QuantityInPackage = 1,
                     });
                 double resinWearCosts = resinTank.CalculateCosts();
-                Assert.IsTrue(resinWearCosts == 0.05d);
+                Assert.IsTrue(resinWearCosts == 0.5d);
                 // Consumable goods (like filters and gloves)
                 ProcedureAddition gloves = new()
                 {
@@ -960,6 +1001,8 @@ namespace AndreasReitberger.NUnitTest
                 Assert.IsTrue(glovesCosts == 1d);
 
                 var calculation = GetTestCalculation();
+                calculation.ProcedureAdditions.Add(resinTank);
+                calculation.ProcedureAdditions.Add(gloves);
                 calculation.Procedure = Material3dFamily.Resin;
                 calculation.ApplyProcedureSpecificAdditions = true;
                 calculation.CalculateCosts();

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
@@ -71,8 +71,27 @@ namespace AndreasReitberger.NUnitTest
                     MultiplyPrintTimeWithQuantity = false
                 };
 
+                Item3d item = new()
+                {
+                    Name = "Nuts M3",
+                    PackageSize = 100,
+                    PackagePrice = 9.99d,
+                    Manufacturer = new()
+                    {
+                        Name = "Würth"
+                    },
+                    SKU = "2302423-1223"
+                };
+                Item3dUsage usage = new()
+                {
+                    Item = item,
+                    Quantity = 30,
+                    LinkedToFile = false,
+                };
+
                 _calculation = new();
                 // Add data
+                _calculation.AdditionalItems.Add(usage);
                 _calculation.Files.Add(file);
                 _calculation.Files.Add(file2);
                 _calculation.Printers.Add(printer);
@@ -107,6 +126,7 @@ namespace AndreasReitberger.NUnitTest
                     _calculation.MaterialCosts,
                     _calculation.CalculatedMargin,
                     _calculation.CalculatedTax,
+                    _calculation.ItemsCosts,
                 };
                 double summedCalc = costsCalc.Sum();
                 Assert.IsTrue(Math.Round(summedCalc, 2) == Math.Round(_calculation.TotalCosts, 2));
@@ -123,6 +143,7 @@ namespace AndreasReitberger.NUnitTest
                     _calculation2.MaterialCosts,
                     _calculation2.CalculatedMargin,
                     _calculation2.CalculatedTax,
+                    _calculation2.ItemsCosts,
                 };
                 summedCalc = costsCalc.Sum();
                 Assert.IsTrue(Math.Round(summedCalc, 2) == Math.Round(_calculation2.TotalCosts, 2));
@@ -434,8 +455,27 @@ namespace AndreasReitberger.NUnitTest
                 MultiplyPrintTimeWithQuantity = false
             };
 
+            Item3d item = new()
+            {
+                Name = "Nuts M3",
+                PackageSize = 100,
+                PackagePrice = 9.99d,
+                Manufacturer = new()
+                {
+                    Name = "Würth"
+                },
+                SKU = "2302423-1223"
+            };
+            Item3dUsage usage = new()
+            {
+                Item = item,
+                Quantity = 30,
+                LinkedToFile = false,
+            };
+
             _calculation = new Calculation3d();
             // Add data
+            _calculation.AdditionalItems.Add(usage);
             _calculation.Files.Add(file);
             _calculation.Files.Add(file2);
             _calculation.Printers.Add(printer);
@@ -693,13 +733,13 @@ namespace AndreasReitberger.NUnitTest
                             Name = "Tank replacement costs",
                             Type = ProcedureCalculationType.ReplacementCosts,
                             Price = 50,
-                            WearFactor = 1000,
+                            WearFactor = 1,
                             QuantityInPackage = 1,
                         }
                     }
                 };
                 double resinWearCosts = resinTank.CalculateCosts();
-                Assert.IsTrue(resinWearCosts == 0.05d);
+                Assert.IsTrue(resinWearCosts == 0.5d);
                 // Consumable goods (like filters and gloves)
                 ProcedureAddition gloves = new()
                 {

--- a/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3d.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3d.cs
@@ -238,6 +238,17 @@ namespace AndreasReitberger.Print3d.Realm
             }
         }
         [JsonIgnore, Ignored]
+        public double ItemsCosts
+        {
+            get
+            {
+                if (IsCalculated)
+                    return GetTotalCosts(CalculationAttributeType.AdditionalItem);
+                else
+                    return 0;
+            }
+        }
+        [JsonIgnore, Ignored]
         public double EnergyCosts
         {
             get

--- a/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3dProfile.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3dProfile.cs
@@ -1,7 +1,9 @@
 ﻿using AndreasReitberger.Print3d.Interfaces;
+using CommunityToolkit.Mvvm.ComponentModel;
 using Realms;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace AndreasReitberger.Print3d.Realm
 {
@@ -124,6 +126,17 @@ namespace AndreasReitberger.Print3d.Realm
         public IList<ProcedureAddition> ProcedureAdditions { get; }
         #endregion
 
+        #endregion
+
+        #region Presets
+
+        public IList<Printer3d> Printers { get; }
+
+        public IList<Material3d> Materials { get; }
+
+        public IList<Item3dUsage> Items { get; }
+
+        public IList<Workstep> Worksteps { get; }
         #endregion
 
         #endregion

--- a/source/3dPrintCalculatorLibrary.Realm/Models/Item3d.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/Item3d.cs
@@ -25,6 +25,8 @@ namespace AndreasReitberger.Print3d.Realm
 
         public string SKU { get; set; } = string.Empty;
 
+        public Manufacturer Manufacturer { get; set; }
+
         public double PackageSize { get; set; } = 1;
 
         public double PackagePrice { get; set; }

--- a/source/3dPrintCalculatorLibrary.Realm/Models/WorkstepAdditions/WorkstepDuration.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/WorkstepAdditions/WorkstepDuration.cs
@@ -10,9 +10,7 @@ namespace AndreasReitberger.Print3d.Realm.WorkstepAdditions
         [PrimaryKey]
         public Guid Id { get; set; }
 
-        public Guid CalculationId { get; set; }
-
-        public Calculation3d Calculation { get; set; }
+        public Workstep Workstep { get; set; }
 
         public Guid WorkstepId { get; set; }
 

--- a/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.Library.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.Library.cs
@@ -7,6 +7,7 @@ using AndreasReitberger.Print3d.SQLite.PrinterAdditions;
 using AndreasReitberger.Print3d.SQLite.StorageAdditions;
 using AndreasReitberger.Print3d.SQLite.WorkstepAdditions;
 using SQLiteNetExtensionsAsync.Extensions;
+using AndreasReitberger.Print3d.Interfaces;
 
 namespace AndreasReitberger.Print3d.SQLite
 {
@@ -769,6 +770,8 @@ namespace AndreasReitberger.Print3d.SQLite
 
         public async Task SetItemsWithChildrenAsync(List<Item3d> items, bool replaceExisting = true)
         {
+            List<Manufacturer> itemCollection = items.Select(i => i.Manufacturer).ToList();
+            await SetManufacturersWithChildrenAsync(itemCollection, replaceExisting);
             if (replaceExisting)
                 await DatabaseAsync.InsertOrReplaceAllWithChildrenAsync(items);
             else
@@ -804,6 +807,8 @@ namespace AndreasReitberger.Print3d.SQLite
 
         public async Task SetItemUsagesWithChildrenAsync(List<Item3dUsage> items, bool replaceExisting = true)
         {
+            List<Item3d> itemCollection = items.Select(i => i.Item).ToList();
+            await SetItemsWithChildrenAsync(itemCollection, replaceExisting);
             if (replaceExisting)
                 await DatabaseAsync.InsertOrReplaceAllWithChildrenAsync(items);
             else

--- a/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.cs
@@ -64,6 +64,55 @@ namespace AndreasReitberger.Print3d.SQLite
         List<Type> tables = new();
 
         [ObservableProperty]
+        List<Type> defaultTables = new()
+        {
+            typeof(Manufacturer),
+            typeof(Supplier),
+            typeof(Printer3d),
+            typeof(Printer3dAttribute),
+            typeof(Printer3dSlicerConfig),
+            typeof(Maintenance3d),
+            typeof(Sparepart),
+            typeof(Material3dColor),
+            typeof(Material3dType),
+            typeof(Material3dAttribute),
+            typeof(Material3dProcedureAttribute),
+            typeof(Material3d),
+            typeof(WorkstepCategory),
+            typeof(Workstep),
+            typeof(HourlyMachineRate),
+            typeof(Customer3d),
+            typeof(CustomAddition),
+            typeof(CalculationAttribute),
+            typeof(CalculationProcedureAttribute),
+            typeof(CalculationProcedureParameter),
+            typeof(CalculationProcedureParameterAddition),
+            typeof(Calculation3d),
+            typeof(File3d),
+            typeof(ModelWeight),
+            typeof(Address),
+            typeof(Email),
+            typeof(PhoneNumber),
+            typeof(ContactPerson),
+            typeof(Calculation3dProfile),
+            typeof(Printer3dCalculation),
+            typeof(Material3dCalculation),
+            typeof(WorkstepCalculation),
+            typeof(CustomAdditionCalculation),
+            typeof(WorkstepDuration),
+            typeof(Item3d),
+            typeof(Item3dCalculation),
+            typeof(Item3dUsage),
+            typeof(Storage3dItem),
+            typeof(Storage3dTransaction),
+            typeof(Storage3d),
+            typeof(ProcedureAddition),
+            typeof(ProcedureCalculationParameter),
+
+            typeof(DatabaseSettingsKeyValuePair),
+        };
+
+        [ObservableProperty]
         Func<Type, Task> onDatabaseOpertions;
         #endregion
 
@@ -155,6 +204,8 @@ namespace AndreasReitberger.Print3d.SQLite
         #region Init
         public void InitTables()
         {
+            DefaultTables?.ForEach(type => Database?.CreateTable(type));
+            /*
             Database?.CreateTable<Manufacturer>();
             Database?.CreateTable<Supplier>();
             Database?.CreateTable<Printer3d>();
@@ -190,6 +241,7 @@ namespace AndreasReitberger.Print3d.SQLite
             Database?.CreateTable<CustomAdditionCalculation>();
             Database?.CreateTable<WorkstepDuration>();
             Database?.CreateTable<Item3d>();
+            Database?.CreateTable<Item3dCalculation>();
             Database?.CreateTable<Item3dUsage>();
             Database?.CreateTable<Storage3dItem>();
             Database?.CreateTable<Storage3dTransaction>();
@@ -198,10 +250,13 @@ namespace AndreasReitberger.Print3d.SQLite
             Database?.CreateTable<ProcedureCalculationParameter>();
 
             Database?.CreateTable<DatabaseSettingsKeyValuePair>();
+            */
         }
 
         public async Task InitTablesAsync()
         {
+            DefaultTables?.ForEach(async type => await DatabaseAsync.CreateTableAsync(type));
+            /*
             await DatabaseAsync.CreateTableAsync<Manufacturer>();
             await DatabaseAsync.CreateTableAsync<Supplier>();
             await DatabaseAsync.CreateTableAsync<Printer3d>();
@@ -237,6 +292,7 @@ namespace AndreasReitberger.Print3d.SQLite
             await DatabaseAsync.CreateTableAsync<CustomAdditionCalculation>();
             await DatabaseAsync.CreateTableAsync<WorkstepDuration>();
             await DatabaseAsync.CreateTableAsync<Item3d>();
+            await DatabaseAsync.CreateTableAsync<Item3dCalculation>();
             await DatabaseAsync.CreateTableAsync<Item3dUsage>();
             await DatabaseAsync.CreateTableAsync<Storage3dItem>();
             await DatabaseAsync.CreateTableAsync<Storage3dTransaction>();
@@ -245,6 +301,7 @@ namespace AndreasReitberger.Print3d.SQLite
             await DatabaseAsync.CreateTableAsync<ProcedureCalculationParameter>();
 
             await DatabaseAsync.CreateTableAsync<DatabaseSettingsKeyValuePair>();
+            */
         }
 
         public void CreateTable(Type table)

--- a/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandlerBuilder.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandlerBuilder.cs
@@ -23,6 +23,8 @@ namespace AndreasReitberger.Print3d.SQLite
                     {
                         _databaseHandler.CreateTables(_databaseHandler.Tables);
                     }
+                    else 
+                        _databaseHandler.InitTables();
                 }
                 return _databaseHandler;
             }
@@ -30,6 +32,12 @@ namespace AndreasReitberger.Print3d.SQLite
             public DatabaseHandlerBuilder WithDatabasePath(string databasePath)
             {
                 _databaseHandler.DatabasePath = databasePath;
+                return this;
+            }
+
+            public DatabaseHandlerBuilder WithDefaultTables()
+            {
+                _databaseHandler.Tables?.AddRange(_databaseHandler.DefaultTables);
                 return this;
             }
 

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3d.cs
@@ -276,6 +276,17 @@ namespace AndreasReitberger.Print3d.SQLite
             }
         }
         [Ignore, JsonIgnore]
+        public double ItemsCost
+        {
+            get
+            {
+                if (IsCalculated)
+                    return GetTotalCosts(CalculationAttributeType.AdditionalItem);
+                else
+                    return 0;
+            }
+        }
+        [Ignore, JsonIgnore]
         public double EnergyCosts
         {
             get

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3dProfile.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3dProfile.cs
@@ -188,6 +188,25 @@ namespace AndreasReitberger.Print3d.SQLite
 
         #endregion
 
+        #region Presets
+
+        [ObservableProperty]
+        [property: OneToMany(CascadeOperations = CascadeOperation.All)]
+        ObservableCollection<Printer3d> printers = new();
+
+        [ObservableProperty]
+        [property: OneToMany(CascadeOperations = CascadeOperation.All)]
+        ObservableCollection<Material3d> materials = new();
+
+        [ObservableProperty]
+        [property: OneToMany(CascadeOperations = CascadeOperation.All)]
+        ObservableCollection<Item3dUsage> items = new();
+
+        [ObservableProperty]
+        [property: OneToMany(CascadeOperations = CascadeOperation.All)]
+        ObservableCollection<Workstep> worksteps = new();
+        #endregion
+
         #endregion
 
         #region Constructor

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/CalculationAdditions/Item3dCalculation.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/CalculationAdditions/Item3dCalculation.cs
@@ -1,0 +1,13 @@
+﻿using SQLiteNetExtensions.Attributes;
+
+namespace AndreasReitberger.Print3d.SQLite.CalculationAdditions
+{
+    public class Item3dCalculation
+    {
+        [ForeignKey(typeof(Item3d))]
+        public Guid ItemId { get; set; }
+
+        [ForeignKey(typeof(Calculation3d))]
+        public Guid CalculationId { get; set; }
+    }
+}

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Item3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Item3d.cs
@@ -36,7 +36,7 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid manufacturerId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(ManufacturerId))]
+        [property: ManyToOne(nameof(ManufacturerId), CascadeOperations = CascadeOperation.All)]
         Manufacturer manufacturer;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Item3dUsage.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Item3dUsage.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using Newtonsoft.Json;
 using SQLite;
 using SQLiteNetExtensions.Attributes;
+using System.Xml.Serialization;
 
 namespace AndreasReitberger.Print3d.SQLite
 {
@@ -29,7 +30,12 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid calculationId;
 
         [ObservableProperty]
-        [property: ForeignKey(typeof(Item3d))]
+        [property: ForeignKey(typeof(Calculation3dProfile))]
+        Guid calculationProfileId;
+
+        [ObservableProperty]
+        //[property: ForeignKey(typeof(Item3d))]
+        [property: JsonIgnore, XmlIgnore]
         Guid itemId;
 
         [ObservableProperty]
@@ -37,7 +43,8 @@ namespace AndreasReitberger.Print3d.SQLite
         Item3d item;
 
         [ObservableProperty]
-        [property: ForeignKey(typeof(File3d))]
+        //[property: ForeignKey(typeof(File3d))]
+        [property: JsonIgnore, XmlIgnore]
         Guid? fileId;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Material3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Material3d.cs
@@ -29,6 +29,10 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid calculationId;
 
         [ObservableProperty]
+        [property: ForeignKey(typeof(Calculation3dProfile))]
+        Guid calculationProfileId;
+
+        [ObservableProperty]
         string name = string.Empty;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Printer3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Printer3d.cs
@@ -23,6 +23,10 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid calculationId;
 
         [ObservableProperty]
+        [property: ForeignKey(typeof(Calculation3dProfile))]
+        Guid calculationProfileId;
+
+        [ObservableProperty]
         string model = string.Empty;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Workstep.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Workstep.cs
@@ -23,6 +23,10 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid calculationId;
 
         [ObservableProperty]
+        [property: ForeignKey(typeof(Calculation3dProfile))]
+        Guid calculationProfileId;
+
+        [ObservableProperty]
         string name = string.Empty;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/WorkstepAdditions/WorkstepDuration.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/WorkstepAdditions/WorkstepDuration.cs
@@ -2,7 +2,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using SQLite;
 using SQLiteNetExtensions.Attributes;
-using System;
 
 namespace AndreasReitberger.Print3d.SQLite.WorkstepAdditions
 {
@@ -15,15 +14,21 @@ namespace AndreasReitberger.Print3d.SQLite.WorkstepAdditions
         Guid id;
 
         [ObservableProperty]
+        Guid workstepId;
+
+        [ObservableProperty]
         [property: ForeignKey(typeof(Calculation3d))]
         Guid calculationId;
 
+        /*
         [ObservableProperty]
         [property: ManyToOne]
         Calculation3d calculation;
+        */
 
         [ObservableProperty]
-        Guid workstepId;
+        [property: ManyToOne(nameof(WorkstepId))]
+        Workstep workstep;
 
         [ObservableProperty]
         double duration = 0;

--- a/source/3dPrintCalculatorLibrary/Interfaces/IWorkstepDuration.cs
+++ b/source/3dPrintCalculatorLibrary/Interfaces/IWorkstepDuration.cs
@@ -6,8 +6,6 @@ namespace AndreasReitberger.Print3d.Interfaces
     {
         #region Properties
         public Guid Id { get; set; }
-        public Guid CalculationId { get; set; }
-        //public ICalculation3d Calculation { get; set; }
         public Guid WorkstepId { get; set; }
         public double Duration { get; set; }
         #endregion

--- a/source/3dPrintCalculatorLibrary/Models/Calculation3d.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Calculation3d.cs
@@ -247,6 +247,17 @@ namespace AndreasReitberger.Print3d.Models
             }
         }
         [JsonIgnore]
+        public double ItemsCosts
+        {
+            get
+            {
+                if (IsCalculated)
+                    return GetTotalCosts(CalculationAttributeType.AdditionalItem);
+                else
+                    return 0;
+            }
+        }
+        [JsonIgnore]
         public double EnergyCosts
         {
             get

--- a/source/3dPrintCalculatorLibrary/Models/Calculation3dProfile.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Calculation3dProfile.cs
@@ -180,6 +180,21 @@ namespace AndreasReitberger.Print3d.Models
 
         #endregion
 
+        #region Presets
+
+        [ObservableProperty]
+        ObservableCollection<IPrinter3d> printers = new();
+
+        [ObservableProperty]
+        ObservableCollection<IMaterial3d> materials = new();
+
+        [ObservableProperty]
+        ObservableCollection<IItem3dUsage> items = new();
+
+        [ObservableProperty]
+        ObservableCollection<IWorkstep> worksteps = new();
+        #endregion
+
         #endregion
 
         #endregion

--- a/source/3dPrintCalculatorLibrary/Models/WorkstepAdditions/WorkstepDuration.cs
+++ b/source/3dPrintCalculatorLibrary/Models/WorkstepAdditions/WorkstepDuration.cs
@@ -11,10 +11,7 @@ namespace AndreasReitberger.Print3d.Models.WorkstepAdditions
         Guid id;
 
         [ObservableProperty]
-        Guid calculationId;
-
-        [ObservableProperty]
-        Calculation3d calculation;
+        Workstep workstep;
 
         [ObservableProperty]
         Guid workstepId;


### PR DESCRIPTION
This PR adds the ability to the `Calculation3dProfile` to also hold lists of printers, materials, items and worksteps.