### PR TITLE
Fixed `ManyToOne` relation for recursive calls

### DIFF
--- a/common.props
+++ b/common.props
@@ -1,7 +1,7 @@
 
 <Project>
     <PropertyGroup>
-        <Version>1.2.1</Version>
+        <Version>1.2.2</Version>
         <!--<PackageIcon>logo_128.png</PackageIcon>-->
         <NeutralLanguage>en</NeutralLanguage>
 		<PackageProjectUrl>https://github.com/AndreasReitberger/3dPrintCostCalculatorSharp</PackageProjectUrl>

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
@@ -917,11 +917,11 @@ namespace AndreasReitberger.NUnitTest
                     Name = "Tank replacement costs",
                     Type = ProcedureCalculationType.ReplacementCosts,
                     Price = 50,
-                    WearFactor = 1000,
+                    WearFactor = 1,
                     QuantityInPackage = 1,
                 });
             double resinWearCosts = resinTank.CalculateCosts();
-            Assert.IsTrue(resinWearCosts == 0.05d);
+            Assert.IsTrue(resinWearCosts == 0.5d);
             // Consumable goods (like filters and gloves)
             ProcedureAddition gloves = new()
             {

--- a/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.Library.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.Library.cs
@@ -8,6 +8,7 @@ using AndreasReitberger.Print3d.SQLite.StorageAdditions;
 using AndreasReitberger.Print3d.SQLite.WorkstepAdditions;
 using SQLiteNetExtensionsAsync.Extensions;
 using AndreasReitberger.Print3d.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AndreasReitberger.Print3d.SQLite
 {
@@ -770,8 +771,13 @@ namespace AndreasReitberger.Print3d.SQLite
 
         public async Task SetItemsWithChildrenAsync(List<Item3d> items, bool replaceExisting = true)
         {
-            List<Manufacturer> itemCollection = items.Select(i => i.Manufacturer).ToList();
-            await SetManufacturersWithChildrenAsync(itemCollection, replaceExisting);
+            List<Manufacturer> itemCollection = items
+                .Select(i => i.Manufacturer)
+                .Where(i => i is not null)
+                .ToList()
+                ;
+            if(itemCollection?.Count > 0)
+                await SetManufacturersWithChildrenAsync(itemCollection, replaceExisting);
             if (replaceExisting)
                 await DatabaseAsync.InsertOrReplaceAllWithChildrenAsync(items);
             else
@@ -807,8 +813,13 @@ namespace AndreasReitberger.Print3d.SQLite
 
         public async Task SetItemUsagesWithChildrenAsync(List<Item3dUsage> items, bool replaceExisting = true)
         {
-            List<Item3d> itemCollection = items.Select(i => i.Item).ToList();
-            await SetItemsWithChildrenAsync(itemCollection, replaceExisting);
+            List<Item3d> itemCollection = items
+                .Select(i => i.Item)
+                .Where(i => i is not null)
+                .ToList()
+                ;
+            if(itemCollection?.Count > 0)
+                await SetItemsWithChildrenAsync(itemCollection, replaceExisting);
             if (replaceExisting)
                 await DatabaseAsync.InsertOrReplaceAllWithChildrenAsync(items);
             else

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3d.cs
@@ -83,7 +83,7 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid customerId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(CustomerId))]
+        [property: ManyToOne(nameof(CustomerId), CascadeOperations = CascadeOperation.All)]
         Customer3d customer;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Customer3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Customer3d.cs
@@ -52,7 +52,7 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid contactPersonId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(ContactPersonId))]
+        [property: ManyToOne(nameof(ContactPersonId), CascadeOperations = CascadeOperation.All)]
         ContactPerson contactPerson;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/File3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/File3d.cs
@@ -46,7 +46,7 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid modelWeightId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(ModelWeightId))]
+        [property: ManyToOne(nameof(ModelWeightId), CascadeOperations = CascadeOperation.All)]
         ModelWeight weight = new(-1, Enums.Unit.Gram);
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Item3dUsage.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Item3dUsage.cs
@@ -39,7 +39,7 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid itemId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(ItemId))]
+        [property: ManyToOne(nameof(ItemId), CascadeOperations = CascadeOperation.All)]
         Item3d item;
 
         [ObservableProperty]
@@ -48,7 +48,7 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid? fileId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(FileId))]
+        [property: ManyToOne(nameof(FileId), CascadeOperations = CascadeOperation.All)]
         File3d file;
         partial void OnFileChanged(File3d value)
         {

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Material3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Material3d.cs
@@ -70,7 +70,7 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid materialTypeId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(MaterialTypeId))]
+        [property: ManyToOne(nameof(MaterialTypeId), CascadeOperations = CascadeOperation.All)]
         Material3dType typeOfMaterial;
 
         [ObservableProperty]
@@ -78,7 +78,7 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid manufacturerId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(ManufacturerId))]
+        [property: ManyToOne(nameof(ManufacturerId), CascadeOperations = CascadeOperation.All)]
         Manufacturer manufacturer;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Printer3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Printer3d.cs
@@ -36,7 +36,7 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid manufacturerId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(ManufacturerId))]
+        [property: ManyToOne(nameof(ManufacturerId), CascadeOperations = CascadeOperation.All)]
         Manufacturer manufacturer;
 
         [ObservableProperty]
@@ -77,7 +77,7 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid hourlyMachineRateId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(HourlyMachineRateId))]
+        [property: ManyToOne(nameof(HourlyMachineRateId), CascadeOperations = CascadeOperation.All)]
         HourlyMachineRate hourlyMachineRate;
 
         [ObservableProperty]
@@ -88,7 +88,7 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid slicerConfigId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(SlicerConfigId))]
+        [property: ManyToOne(nameof(SlicerConfigId), CascadeOperations = CascadeOperation.All)]
         Printer3dSlicerConfig slicerConfig = new();
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/SlicerAdditions/Slicer3dCommand.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/SlicerAdditions/Slicer3dCommand.cs
@@ -20,7 +20,7 @@ namespace AndreasReitberger.Print3d.SQLite.SlicerAdditions
         Guid slicerId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(SlicerId))]
+        [property: ManyToOne(nameof(SlicerId), CascadeOperations = CascadeOperation.All)]
         Slicer3d slicer;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dItem.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dItem.cs
@@ -24,7 +24,7 @@ namespace AndreasReitberger.Print3d.SQLite.StorageAdditions
         Guid materialId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(MaterialId))]
+        [property: ManyToOne(nameof(MaterialId), CascadeOperations = CascadeOperation.All)]
         Material3d material;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dTransaction.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dTransaction.cs
@@ -18,7 +18,7 @@ namespace AndreasReitberger.Print3d.SQLite.StorageAdditions
         Guid? calculationId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(CalculationId))]
+        [property: ManyToOne(nameof(CalculationId), CascadeOperations = CascadeOperation.All)]
         Calculation3d? calculation;
 
         [ObservableProperty]
@@ -28,7 +28,7 @@ namespace AndreasReitberger.Print3d.SQLite.StorageAdditions
         Guid storageItemId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(StorageItemId))]
+        [property: ManyToOne(nameof(StorageItemId), CascadeOperations = CascadeOperation.All)]
         Storage3dItem item;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Workstep.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Workstep.cs
@@ -47,7 +47,7 @@ namespace AndreasReitberger.Print3d.SQLite
         Guid categoryId;
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(CategoryId))]
+        [property: ManyToOne(nameof(CategoryId), CascadeOperations = CascadeOperation.All)]
         WorkstepCategory category;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/WorkstepAdditions/WorkstepDuration.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/WorkstepAdditions/WorkstepDuration.cs
@@ -27,7 +27,7 @@ namespace AndreasReitberger.Print3d.SQLite.WorkstepAdditions
         */
 
         [ObservableProperty]
-        [property: ManyToOne(nameof(WorkstepId))]
+        [property: ManyToOne(nameof(WorkstepId), CascadeOperations = CascadeOperation.All)]
         Workstep workstep;
 
         [ObservableProperty]


### PR DESCRIPTION
If loading an item, which has an item which has a `ManyToOne` relation (depth > 1), then the property was not loaded from the SQLite database.

Also the tests have been updated and fixed.

Fixed #77