### PR TITLE
Recoded `Workstep` for better parameter handling

### DIFF
--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
@@ -3,6 +3,7 @@ using AndreasReitberger.Print3d.Realm;
 using AndreasReitberger.Print3d.Realm.CalculationAdditions;
 using AndreasReitberger.Print3d.Realm.MaterialAdditions;
 using AndreasReitberger.Print3d.Realm.StorageAdditions;
+using AndreasReitberger.Print3d.Realm.WorkstepAdditions;
 using AndreasReitberger.Print3d.Realm.ProcedureAdditions;
 using NUnit.Framework;
 using Realms;
@@ -616,6 +617,7 @@ namespace AndreasReitberger.NUnitTest
             }
         }
 
+        [Test]
         public void MultiFileDifferTest()
         {
             try
@@ -724,6 +726,94 @@ namespace AndreasReitberger.NUnitTest
 
                 Assert.IsTrue(_calculation.IsCalculated);
                 Assert.IsTrue(total == totalDiffer);
+            }
+            catch (Exception exc)
+            {
+                Assert.Fail(exc.Message);
+            }
+        }
+
+
+        [Test]
+        public void Item3dTests()
+        {
+            try
+            {
+                Manufacturer wuerth = new()
+                {
+                    Name = "Würth",
+                    DebitorNumber = "DE26265126",
+                    Website = "https://www.wuerth.de/",
+                };
+
+                Item3d item1 = new()
+                {
+                    Name = "Nuts M3",
+                    PackageSize = 100,
+                    PackagePrice = 9.99d,
+                    Manufacturer = wuerth,
+                    SKU = "2302423-1223"
+                };
+                Item3d item2 = new()
+                {
+                    Name = "Screws M3 20mm",
+                    PackageSize = 50,
+                    PackagePrice = 14.99d,
+                    Manufacturer = wuerth,
+                    SKU = "2302423-6413"
+                };
+
+                Assert.IsNotNull(item1);
+                Assert.IsNotNull(item2);
+                Assert.IsNotNull(item1?.Manufacturer);
+                Assert.IsNotNull(item2?.Manufacturer);
+
+                Item3dUsage usage = new()
+                {
+                    Item = item1,
+                    Quantity = 30,
+                    LinkedToFile = false,
+                };
+                Assert.IsNotNull(usage);
+                Assert.IsNotNull(usage.Item);
+
+                var manufacturerLoaded = usage?.Item?.Manufacturer;
+                Assert.IsNotNull(manufacturerLoaded);
+            }
+            catch (Exception exc)
+            {
+                Assert.Fail(exc.Message);
+            }
+        }
+
+        [Test]
+        public void WorkstepTests()
+        {
+            try
+            {
+                WorkstepCategory category = new()
+                {
+                    Name = "Construction"
+                };
+                Workstep ws = new()
+                {
+                    Name = "3D CAD",
+                    Category = category,
+                    Price = 30,
+                };
+                WorkstepUsage usage = new()
+                {
+                    Workstep = ws,
+                    UsageParameter = new()
+                    {
+                        ParameterType = WorkstepUsageParameterType.Duration,
+                        Value = 1.5d
+                    }
+                };
+
+                Assert.IsNotNull(usage);
+                Assert.IsNotNull(usage?.UsageParameter);
+                Assert.IsNotNull(usage?.Workstep);
             }
             catch (Exception exc)
             {

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Sqlite.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Sqlite.cs
@@ -710,6 +710,65 @@ namespace AndreasReitberger.NUnitTest
         }
 
         [Test]
+        public async Task WorkstepTests()
+        {
+            try
+            {
+                string databasePath = "testdatabase_worksteps.db";
+                if (File.Exists(databasePath))
+                {
+                    File.Delete(databasePath);
+                }
+                using DatabaseHandler handler = new DatabaseHandler.DatabaseHandlerBuilder()
+                    .WithDatabasePath(databasePath)
+                    .WithTables(new List<Type> {
+                        typeof(Workstep),
+                        typeof(WorkstepCategory),
+                        typeof(WorkstepUsage),
+                        typeof(WorkstepUsageParameter),
+                    })
+                    .Build();
+                WorkstepCategory category = new()
+                {
+                    Name = "Construction"
+                };
+                await handler.SetWorkstepCategoryWithChildrenAsync(category);
+
+                Workstep ws = new()
+                {
+                    Name = "3D CAD",
+                    Category = category,
+                    Price = 30,
+                };
+                await handler.SetWorkstepWithChildrenAsync(ws);
+
+                WorkstepUsage usage = new()
+                {
+                    Workstep = ws,
+                    UsageParameter = new()
+                    {
+                        ParameterType = WorkstepUsageParameterType.Duration,
+                        Value = 1.5d
+                    }
+                };
+                await handler.SetWorkstepUsageWithChildrenAsync(usage);
+
+
+                WorkstepUsage loadedUsage = await handler.GetWorkstepUsageWithChildrenAsync(usage.Id);
+                Assert.IsNotNull(loadedUsage);
+                Assert.IsNotNull(loadedUsage?.UsageParameter);
+                Assert.IsNotNull(loadedUsage?.Workstep);
+
+                var usages = await handler.GetWorkstepUsagesWithChildrenAsync();
+                Assert.IsTrue(usages?.Count == 1);
+            }
+            catch(Exception exc)
+            {
+                Assert.Fail(exc.Message);
+            }
+        }
+
+        [Test]
         public async Task DatabaseSaveAndLoadTest()
         {
             try

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
@@ -3,6 +3,7 @@ using AndreasReitberger.Print3d.Enums;
 using AndreasReitberger.Print3d.Models;
 using AndreasReitberger.Print3d.Models.CalculationAdditions;
 using AndreasReitberger.Print3d.Models.MaterialAdditions;
+using AndreasReitberger.Print3d.Models.WorkstepAdditions;
 using AndreasReitberger.Print3d.ProcedureAdditions;
 using NUnit.Framework;
 
@@ -532,6 +533,7 @@ namespace AndreasReitberger.NUnitTest
             return _calculation;
         }
 
+        [Test]
         public void MultiFileDifferTest()
         {
             try
@@ -640,6 +642,93 @@ namespace AndreasReitberger.NUnitTest
 
                 Assert.IsTrue(_calculation.IsCalculated);
                 Assert.IsTrue(total == totalDiffer);
+            }
+            catch (Exception exc)
+            {
+                Assert.Fail(exc.Message);
+            }
+        }
+
+        [Test]
+        public void Item3dTests()
+        {
+            try
+            {
+                Manufacturer wuerth = new()
+                {
+                    Name = "Würth",
+                    DebitorNumber = "DE26265126",
+                    Website = "https://www.wuerth.de/",
+                };
+
+                Item3d item1 = new()
+                {
+                    Name = "Nuts M3",
+                    PackageSize = 100,
+                    PackagePrice = 9.99d,
+                    Manufacturer = wuerth,
+                    SKU = "2302423-1223"
+                };
+                Item3d item2 = new()
+                {
+                    Name = "Screws M3 20mm",
+                    PackageSize = 50,
+                    PackagePrice = 14.99d,
+                    Manufacturer = wuerth,
+                    SKU = "2302423-6413"
+                };
+
+                Assert.IsNotNull(item1);
+                Assert.IsNotNull(item2);
+                Assert.IsNotNull(item1?.Manufacturer);
+                Assert.IsNotNull(item2?.Manufacturer);
+
+                Item3dUsage usage = new()
+                {
+                    Item = item1,
+                    Quantity = 30,
+                    LinkedToFile = false,
+                };
+                Assert.IsNotNull(usage);
+                Assert.IsNotNull(usage.Item);
+
+                var manufacturerLoaded = usage?.Item?.Manufacturer;
+                Assert.IsNotNull(manufacturerLoaded);
+            }
+            catch (Exception exc)
+            {
+                Assert.Fail(exc.Message);
+            }
+        }
+
+        [Test]
+        public void WorkstepTests()
+        {
+            try
+            {
+                WorkstepCategory category = new()
+                {
+                    Name = "Construction"
+                };
+                Workstep ws = new()
+                {
+                    Name = "3D CAD",
+                    Category = category,
+                    Price = 30,
+                };
+                WorkstepUsage usage = new()
+                {
+                    Workstep = ws,
+                    UsageParameter = new()
+                    {
+                        ParameterType = WorkstepUsageParameterType.Duration,
+                        Value = 1.5d
+                    }
+                };
+
+                Assert.IsNotNull(usage);
+                Assert.IsNotNull(usage?.UsageParameter);
+                Assert.IsNotNull(usage?.Workstep);
             }
             catch (Exception exc)
             {

--- a/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3d.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3d.Extensions.cs
@@ -289,12 +289,32 @@ namespace AndreasReitberger.Print3d.Realm
                 }
 
                 // Worksteps
+                // Delete once migrated to `WorkstepUsage` instead
                 if (WorkSteps?.Count > 0)
                 {
                     // Only take the worksteps, which are set as `PerPiece` here
                     foreach (Workstep ws in WorkSteps.Where(ws => ws.CalculationType == CalculationType.PerPiece))
                     {
                         double totalPerPiece = ws.TotalCosts * file.Quantity;
+                        Costs?.Add(new CalculationAttribute()
+                        {
+                            LinkedId = ws.Id,
+                            Attribute = ws.Name,
+                            Type = CalculationAttributeType.Workstep,
+                            Value = totalPerPiece,
+                            FileId = file.Id,
+                            FileName = file.FileName,
+                        });
+                    }
+                }
+                if (WorkstepUsages?.Count > 0)
+                {
+                    // Only take the worksteps, which are set as `PerPiece` here
+                    foreach (WorkstepUsage wsu in WorkstepUsages.Where(wsu => wsu?.Workstep?.CalculationType == CalculationType.PerPiece))
+                    {
+                        Workstep ws = wsu.Workstep;
+                        if (ws is null) continue;
+                        double totalPerPiece = wsu.TotalCosts * file.Quantity;
                         Costs?.Add(new CalculationAttribute()
                         {
                             LinkedId = ws.Id,
@@ -448,6 +468,7 @@ namespace AndreasReitberger.Print3d.Realm
             }
 
             // Worksteps
+            // Delete once migrated to `WorkstepUsage` instead
             if (WorkSteps?.Count > 0)
             {
                 foreach (Workstep ws in WorkSteps.Where(ws => ws.CalculationType != CalculationType.PerPiece))
@@ -488,6 +509,22 @@ namespace AndreasReitberger.Print3d.Realm
                             // Nothing to do here
                             break;
                     }
+                }
+            }
+            if (WorkstepUsages?.Count > 0)
+            {
+                foreach (WorkstepUsage wsu in WorkstepUsages.Where(wsu => wsu?.Workstep?.CalculationType != CalculationType.PerPiece))
+                {
+                    Workstep ws = wsu.Workstep;
+                    if (ws is null) continue;
+                    double totalPerJob = wsu.TotalCosts;
+                    Costs?.Add(new CalculationAttribute()
+                    {
+                        LinkedId = ws.Id,
+                        Attribute = ws.Name,
+                        Type = CalculationAttributeType.Workstep,
+                        Value = totalPerJob,
+                    });
                 }
             }
 

--- a/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3d.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3d.cs
@@ -129,8 +129,12 @@ namespace AndreasReitberger.Print3d.Realm
 
         public IList<CustomAddition> CustomAdditions { get; }
 
+        public IList<WorkstepUsage> WorkstepUsages { get; }
+
+        [Obsolete("Use the WorkstepUsages class instead")]
         public IList<Workstep> WorkSteps { get; }
 
+        [Obsolete("Use the WorkstepUsages class instead")]
         public IList<WorkstepDuration> WorkStepDurations { get; }
 
         public IList<Item3dUsage> AdditionalItems { get; }

--- a/source/3dPrintCalculatorLibrary.Realm/Models/Supplier.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/Supplier.cs
@@ -1,5 +1,4 @@
 ﻿using AndreasReitberger.Print3d.Interfaces;
-using CommunityToolkit.Mvvm.ComponentModel;
 using Realms;
 using System;
 using System.Collections.Generic;

--- a/source/3dPrintCalculatorLibrary.Realm/Models/Workstep.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/Workstep.cs
@@ -1,7 +1,6 @@
 ﻿using AndreasReitberger.Print3d.Enums;
 using AndreasReitberger.Print3d.Interfaces;
 using AndreasReitberger.Print3d.Realm.WorkstepAdditions;
-using CommunityToolkit.Mvvm.ComponentModel;
 using Realms;
 using System;
 
@@ -33,6 +32,8 @@ namespace AndreasReitberger.Print3d.Realm
         }
 
         int quantity { get; set; } = 1;
+
+        [Obsolete("Use the WorkstepUsageParameter instead")]
         public int Quantity
         {
             get => quantity;
@@ -59,6 +60,8 @@ namespace AndreasReitberger.Print3d.Realm
         }
 
         double duration { get; set; } = 0;
+
+        [Obsolete("Use the WorkstepUsageParameter instead")]
         public double Duration
         {
             get => duration;
@@ -80,16 +83,23 @@ namespace AndreasReitberger.Print3d.Realm
             set { TypeId = (int)value; }
         }
 
+
+        [Obsolete("Use the WorkstepUsageParameter instead")]
         public double TotalCosts { get; set; } = 0;
 
         public string Note { get; set; } = string.Empty;
         #endregion
 
         #region Constructors
-        public Workstep() { }
+        public Workstep()
+        {
+            Id = Guid.NewGuid();
+        }
         #endregion
 
         #region Private
+
+        [Obsolete("Use the WorkstepUsageParameter instead")]
         double CalcualteTotalCosts()
         {
             try

--- a/source/3dPrintCalculatorLibrary.Realm/Models/WorkstepAdditions/WorkstepDuration.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/WorkstepAdditions/WorkstepDuration.cs
@@ -4,6 +4,7 @@ using System;
 
 namespace AndreasReitberger.Print3d.Realm.WorkstepAdditions
 {
+    [Obsolete("Use the WorkstepUsage class instead")]
     public partial class WorkstepDuration : RealmObject, IWorkstepDuration
     {
         #region Properties

--- a/source/3dPrintCalculatorLibrary.Realm/Models/WorkstepAdditions/WorkstepUsageParameter.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/WorkstepAdditions/WorkstepUsageParameter.cs
@@ -1,0 +1,46 @@
+﻿using AndreasReitberger.Print3d.Enums;
+using AndreasReitberger.Print3d.Interfaces;
+using Newtonsoft.Json;
+using Realms;
+using System;
+
+namespace AndreasReitberger.Print3d.Realm.WorkstepAdditions
+{
+    public partial class WorkstepUsageParameter : RealmObject, IWorkstepUsageParameter
+    {
+        #region Properties
+        [PrimaryKey]
+        public Guid Id { get; set; }
+
+        public WorkstepUsageParameterType ParameterType
+        {
+            get => (WorkstepUsageParameterType)ParameterTypeId;
+            set { ParameterTypeId = (int)value; }
+        }
+        public int ParameterTypeId { get; set; } = (int)WorkstepUsageParameterType.Quantity;
+
+        public double Value { get; set; } = 0;
+        #endregion
+
+        #region Constructors
+        public WorkstepUsageParameter()
+        {
+            Id = Guid.NewGuid();
+        }
+        #endregion
+
+        #region Overrides
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
+        public override bool Equals(object obj)
+        {
+            if (obj is not WorkstepUsageParameter item)
+                return false;
+            return Id.Equals(item.Id);
+        }
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+        #endregion
+    }
+}

--- a/source/3dPrintCalculatorLibrary.Realm/Models/WorkstepUsage.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/WorkstepUsage.cs
@@ -1,0 +1,58 @@
+﻿using AndreasReitberger.Print3d.Interfaces;
+using AndreasReitberger.Print3d.Realm.WorkstepAdditions;
+using Newtonsoft.Json;
+using Realms;
+using System;
+
+namespace AndreasReitberger.Print3d.Realm
+{
+    public partial class WorkstepUsage : RealmObject, IWorkstepUsage
+    {
+        #region Properties
+        [PrimaryKey]
+        public Guid Id { get; set; }
+
+        public Guid CalculationId { get; set; }
+        public Guid WorkstepId { get; set; }
+        public Workstep Workstep { get; set; }
+        public WorkstepUsageParameter UsageParameter { get; set; }
+        public double TotalCosts { get; set; }
+
+        #endregion
+
+        #region Constructors
+        public WorkstepUsage()
+        {
+            Id = Guid.NewGuid();
+        }
+        #endregion
+
+        #region Methods
+        public double GetTotalCosts()
+        {
+            double cost;
+            cost = (UsageParameter?.ParameterType) switch
+            {
+                Enums.WorkstepUsageParameterType.Duration => (Workstep?.Price * UsageParameter?.Value) ?? 0,
+                _ => (Workstep?.Price * UsageParameter?.Value) ?? 0,
+            };
+            return cost;
+        }
+
+        #endregion
+
+        #region Overrides
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
+        public override bool Equals(object obj)
+        {
+            if (obj is not WorkstepUsage item)
+                return false;
+            return Id.Equals(item.Id);
+        }
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+        #endregion
+    }
+}

--- a/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.Library.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.Library.cs
@@ -604,7 +604,7 @@ namespace AndreasReitberger.Print3d.SQLite
         #region Worksteps
         public async Task<List<Workstep>> GetWorkstepsWithChildrenAsync()
         {
-            Worksteps = await DatabaseAsync?
+            Worksteps = await DatabaseAsync
                 .GetAllWithChildrenAsync<Workstep>(recursive: true)
                 ;
             return Worksteps;
@@ -612,29 +612,105 @@ namespace AndreasReitberger.Print3d.SQLite
 
         public async Task<Workstep> GetWorkstepWithChildrenAsync(Guid id)
         {
-            return await DatabaseAsync?
+            return await DatabaseAsync
                 .GetWithChildrenAsync<Workstep>(id, recursive: true)
                 ;
         }
 
         public async Task SetWorkstepWithChildrenAsync(Workstep workstep)
         {
-            await DatabaseAsync?
+            await DatabaseAsync
                 .InsertOrReplaceWithChildrenAsync(workstep, recursive: true)
                 ;
         }
 
-        public async Task SetMWorkstepsWithChildrenAsync(List<Workstep> worksteps, bool replaceExisting = true)
+        public async Task SetWorkstepsWithChildrenAsync(List<Workstep> worksteps, bool replaceExisting = true)
         {
             if (replaceExisting)
-                await DatabaseAsync?.InsertOrReplaceAllWithChildrenAsync(worksteps);
+                await DatabaseAsync.InsertOrReplaceAllWithChildrenAsync(worksteps);
             else
-                await DatabaseAsync?.InsertAllWithChildrenAsync(worksteps);
+                await DatabaseAsync.InsertAllWithChildrenAsync(worksteps);
         }
 
         public async Task<int> DeleteWorkstepAsync(Workstep workstep)
         {
-            return await DatabaseAsync?.DeleteAsync<Workstep>(workstep?.Id);
+            return await DatabaseAsync.DeleteAsync<Workstep>(workstep?.Id);
+        }
+
+        #endregion
+
+        #region WorkstepsUsages
+        public async Task<List<WorkstepUsage>> GetWorkstepUsagesWithChildrenAsync()
+        {
+            WorkstepUsages = await DatabaseAsync
+                .GetAllWithChildrenAsync<WorkstepUsage>(recursive: true)
+                ;
+            return WorkstepUsages;
+        }
+
+        public async Task<WorkstepUsage> GetWorkstepUsageWithChildrenAsync(Guid id)
+        {
+            return await DatabaseAsync
+                .GetWithChildrenAsync<WorkstepUsage>(id, recursive: true)
+                ;
+        }
+
+        public async Task SetWorkstepUsageWithChildrenAsync(WorkstepUsage workstepUsage)
+        {
+            await DatabaseAsync
+                .InsertOrReplaceWithChildrenAsync(workstepUsage, recursive: true)
+                ;
+        }
+
+        public async Task SetWorkstepUsagesWithChildrenAsync(List<WorkstepUsage> workstepUsages, bool replaceExisting = true)
+        {
+            if (replaceExisting)
+                await DatabaseAsync.InsertOrReplaceAllWithChildrenAsync(workstepUsages);
+            else
+                await DatabaseAsync.InsertAllWithChildrenAsync(workstepUsages);
+        }
+
+        public async Task<int> DeleteWorkstepUsageAsync(WorkstepUsage workstepUsage)
+        {
+            return await DatabaseAsync.DeleteAsync<WorkstepUsage>(workstepUsage?.Id);
+        }
+
+        #endregion
+
+        #region WorkstepsUsageParameters
+        public async Task<List<WorkstepUsageParameter>> GetWorkstepUsageParametersWithChildrenAsync()
+        {
+            WorkstepUsageParameters = await DatabaseAsync
+                .GetAllWithChildrenAsync<WorkstepUsageParameter>(recursive: true)
+                ;
+            return WorkstepUsageParameters;
+        }
+
+        public async Task<WorkstepUsageParameter> GetWorkstepUsageParameterWithChildrenAsync(Guid id)
+        {
+            return await DatabaseAsync
+                .GetWithChildrenAsync<WorkstepUsageParameter>(id, recursive: true)
+                ;
+        }
+
+        public async Task SetWorkstepUsageParametersWithChildrenAsync(WorkstepUsageParameter workstepUsageParameter)
+        {
+            await DatabaseAsync
+                .InsertOrReplaceWithChildrenAsync(workstepUsageParameter, recursive: true)
+                ;
+        }
+
+        public async Task SeWorkstepUsageParametersWithChildrenAsync(List<WorkstepUsageParameter> workstepUsageParameters, bool replaceExisting = true)
+        {
+            if (replaceExisting)
+                await DatabaseAsync.InsertOrReplaceAllWithChildrenAsync(workstepUsageParameters);
+            else
+                await DatabaseAsync.InsertAllWithChildrenAsync(workstepUsageParameters);
+        }
+
+        public async Task<int> DeleteWorkstepUsageParameterAsync(WorkstepUsageParameter workstepUsageParameter)
+        {
+            return await DatabaseAsync.DeleteAsync<WorkstepUsageParameter>(workstepUsageParameter?.Id);
         }
 
         #endregion
@@ -642,19 +718,19 @@ namespace AndreasReitberger.Print3d.SQLite
         #region Workstep Categories
         public async Task<List<WorkstepCategory>> GetWorkstepCategoriesWithChildrenAsync()
         {
-            return await DatabaseAsync?
+            return await DatabaseAsync
                 .GetAllWithChildrenAsync<WorkstepCategory>(recursive: true);
         }
 
         public async Task<WorkstepCategory> GetWorkstepCategoryWithChildrenAsync(Guid id)
         {
-            return await DatabaseAsync?
+            return await DatabaseAsync
                 .GetWithChildrenAsync<WorkstepCategory>(id, recursive: true)
                 ;
         }
         public async Task SetWorkstepCategoryWithChildrenAsync(WorkstepCategory workstepCategory)
         {
-            await DatabaseAsync?
+            await DatabaseAsync
                 .InsertOrReplaceWithChildrenAsync(workstepCategory, recursive: true)
                 ;
         }
@@ -662,14 +738,14 @@ namespace AndreasReitberger.Print3d.SQLite
         public async Task SetWorkstepCategoriesWithChildrenAsync(List<WorkstepCategory> categories, bool replaceExisting = true)
         {
             if (replaceExisting)
-                await DatabaseAsync?.InsertOrReplaceAllWithChildrenAsync(categories);
+                await DatabaseAsync.InsertOrReplaceAllWithChildrenAsync(categories);
             else
-                await DatabaseAsync?.InsertAllWithChildrenAsync(categories);
+                await DatabaseAsync.InsertAllWithChildrenAsync(categories);
         }
 
         public async Task<int> DeleteWorkstepCategoryAsync(WorkstepCategory workstepCategory)
         {
-            return await DatabaseAsync?.DeleteAsync<WorkstepCategory>(workstepCategory?.Id);
+            return await DatabaseAsync.DeleteAsync<WorkstepCategory>(workstepCategory?.Id);
         }
 
         #endregion
@@ -678,36 +754,36 @@ namespace AndreasReitberger.Print3d.SQLite
 
         public async Task<List<HourlyMachineRate>> GetHourlyMachineRatesWithChildrenAsync()
         {
-            HourlyMachineRates = await DatabaseAsync?
+            HourlyMachineRates = await DatabaseAsync
                 .GetAllWithChildrenAsync<HourlyMachineRate>(recursive: true);
             return HourlyMachineRates;
         }
 
         public async Task<HourlyMachineRate> GetHourlyMachineRateWithChildrenAsync(Guid id)
         {
-            return await DatabaseAsync?
+            return await DatabaseAsync
                 .GetWithChildrenAsync<HourlyMachineRate>(id, recursive: true);
         }
 
         public async Task SetHourlyMachineRateWithChildrenAsync(HourlyMachineRate hourlyMachineRate, bool replaceExisting = true)
         {
             if (replaceExisting)
-                await DatabaseAsync?.InsertOrReplaceWithChildrenAsync(hourlyMachineRate, recursive: true);
+                await DatabaseAsync.InsertOrReplaceWithChildrenAsync(hourlyMachineRate, recursive: true);
             else
-                await DatabaseAsync?.InsertWithChildrenAsync(hourlyMachineRate);
+                await DatabaseAsync.InsertWithChildrenAsync(hourlyMachineRate);
         }
 
         public async Task SetHourlyMachineRatesWithChildrenAsync(List<HourlyMachineRate> hourlyMachineRates, bool replaceExisting = true)
         {
             if (replaceExisting)
-                await DatabaseAsync?.InsertOrReplaceAllWithChildrenAsync(hourlyMachineRates);
+                await DatabaseAsync.InsertOrReplaceAllWithChildrenAsync(hourlyMachineRates);
             else
-                await DatabaseAsync?.InsertAllWithChildrenAsync(hourlyMachineRates);
+                await DatabaseAsync.InsertAllWithChildrenAsync(hourlyMachineRates);
         }
 
         public async Task<int> DeleteHourlyMachineRateAsync(HourlyMachineRate hourlyMachineRate)
         {
-            return await DatabaseAsync?.DeleteAsync<HourlyMachineRate>(hourlyMachineRate?.Id);
+            return await DatabaseAsync.DeleteAsync<HourlyMachineRate>(hourlyMachineRate?.Id);
         }
 
         #endregion

--- a/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.cs
@@ -100,6 +100,9 @@ namespace AndreasReitberger.Print3d.SQLite
             typeof(WorkstepCalculation),
             typeof(CustomAdditionCalculation),
             typeof(WorkstepDuration),
+            typeof(WorkstepUsage),
+            typeof(WorkstepUsageParameter),
+            typeof(WorkstepUsageCalculation),
             typeof(Item3d),
             typeof(Item3dCalculation),
             typeof(Item3dUsage),
@@ -168,6 +171,30 @@ namespace AndreasReitberger.Print3d.SQLite
             {
                 Worksteps = value,
             });
+        }
+
+        [ObservableProperty]
+        List<WorkstepUsage> workstepUsages = new();
+        partial void OnWorkstepUsagesChanged(List<WorkstepUsage> value)
+        {
+            /*
+            OnWorkstepsChangedEvent(new WorkstepsChangedDatabaseEventArgs()
+            {
+                Worksteps = value,
+            });
+            */
+        }
+
+        [ObservableProperty]
+        List<WorkstepUsageParameter> workstepUsageParameters = new();
+        partial void OnWorkstepUsageParametersChanged(List<WorkstepUsageParameter> value)
+        {
+            /*
+            OnWorkstepsChangedEvent(new WorkstepsChangedDatabaseEventArgs()
+            {
+                Worksteps = value,
+            });
+            */
         }
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3d.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3d.Extensions.cs
@@ -297,12 +297,32 @@ namespace AndreasReitberger.Print3d.SQLite
                 }
 
                 // Worksteps
+                // Delete once migrated to `WorkstepUsage` instead
                 if (WorkSteps?.Count > 0)
                 {
                     // Only take the worksteps, which are set as `PerPiece` here
                     foreach (Workstep ws in WorkSteps.Where(ws => ws.CalculationType == CalculationType.PerPiece))
                     {
                         double totalPerPiece = ws.TotalCosts * file.Quantity;
+                        Costs?.Add(new CalculationAttribute()
+                        {
+                            LinkedId = ws.Id,
+                            Attribute = ws.Name,
+                            Type = CalculationAttributeType.Workstep,
+                            Value = totalPerPiece,
+                            FileId = file.Id,
+                            FileName = file.FileName,
+                        });
+                    }
+                }
+                if (WorkstepUsages?.Count > 0)
+                {
+                    // Only take the worksteps, which are set as `PerPiece` here
+                    foreach (WorkstepUsage wsu in WorkstepUsages.Where(wsu => wsu?.Workstep?.CalculationType == CalculationType.PerPiece))
+                    {
+                        Workstep ws = wsu.Workstep;
+                        if (ws is null) continue;
+                        double totalPerPiece = wsu.TotalCosts * file.Quantity;
                         Costs?.Add(new CalculationAttribute()
                         {
                             LinkedId = ws.Id,
@@ -491,6 +511,7 @@ namespace AndreasReitberger.Print3d.SQLite
             }
 
             // Worksteps
+            // Delete once migrated to `WorkstepUsage` instead
             if (WorkSteps?.Count > 0)
             {
                 foreach (Workstep ws in WorkSteps.Where(ws => ws.CalculationType != CalculationType.PerPiece))
@@ -531,6 +552,22 @@ namespace AndreasReitberger.Print3d.SQLite
                             // Nothing to do here
                             break;
                     }
+                }
+            }
+            if (WorkstepUsages?.Count > 0)
+            {
+                foreach (WorkstepUsage wsu in WorkstepUsages.Where(wsu => wsu?.Workstep?.CalculationType != CalculationType.PerPiece))
+                {
+                    Workstep ws = wsu.Workstep;
+                    if (ws is null) continue;
+                    double totalPerJob = wsu.TotalCosts; 
+                    Costs?.Add(new CalculationAttribute()
+                    {
+                        LinkedId = ws.Id,
+                        Attribute = ws.Name,
+                        Type = CalculationAttributeType.Workstep,
+                        Value = totalPerJob,
+                    });
                 }
             }
 

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3d.cs
@@ -144,12 +144,18 @@ namespace AndreasReitberger.Print3d.SQLite
         List<CustomAddition> customAdditions = new();
 
         [ObservableProperty]
+        [Obsolete("Use the WorkstepUsages class instead")]
         [property: ManyToMany(typeof(WorkstepCalculation))]
         List<Workstep> workSteps = new();
 
         [ObservableProperty]
+        [Obsolete("Use the WorkstepUsages class instead")]
         [property: OneToMany]
         List<WorkstepDuration> workStepDurations = new();
+
+        [ObservableProperty]
+        [property: ManyToMany(typeof(WorkstepUsageCalculation))]
+        List<WorkstepUsage> workstepUsages = new();
 
         [ObservableProperty]
         [property: OneToMany]

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Workstep.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Workstep.cs
@@ -10,7 +10,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace AndreasReitberger.Print3d.SQLite
 {
-    [Table("Worksteps")]
+    [Table($"{nameof(Workstep)}s")]
     public partial class Workstep : ObservableObject, IWorkstep, ICloneable
     {
         #region Properties
@@ -37,6 +37,7 @@ namespace AndreasReitberger.Print3d.SQLite
         }
 
         [ObservableProperty]
+        [Obsolete("Use the WorkstepUsageParameter instead")]
         int quantity = 1;
         partial void OnQuantityChanged(int value)
         {
@@ -54,6 +55,7 @@ namespace AndreasReitberger.Print3d.SQLite
         CalculationType calculationType;
 
         [ObservableProperty]
+        [Obsolete("Use the WorkstepUsageParameter instead")]
         double duration = 0;
         partial void OnDurationChanged(double value)
         {
@@ -64,6 +66,7 @@ namespace AndreasReitberger.Print3d.SQLite
         WorkstepType type;
 
         [ObservableProperty]
+        [Obsolete("Use the WorkstepUsageParameter instead")]
         double totalCosts = 0;
 
         [ObservableProperty]
@@ -75,6 +78,7 @@ namespace AndreasReitberger.Print3d.SQLite
         #endregion
 
         #region Private
+        [Obsolete("Use the WorkstepUsageParameter instead")]
         double CalcualteTotalCosts()
         {
             try

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/WorkstepAdditions/WorkstepDuration.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/WorkstepAdditions/WorkstepDuration.cs
@@ -6,6 +6,7 @@ using SQLiteNetExtensions.Attributes;
 namespace AndreasReitberger.Print3d.SQLite.WorkstepAdditions
 {
     [Table("WorkstepDurations")]
+    [Obsolete("Use the WorkstepUsage class instead")]
     public partial class WorkstepDuration : ObservableObject, IWorkstepDuration
     {
         #region Properties

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/WorkstepAdditions/WorkstepUsageCalculation.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/WorkstepAdditions/WorkstepUsageCalculation.cs
@@ -3,11 +3,10 @@ using System;
 
 namespace AndreasReitberger.Print3d.SQLite.WorkstepAdditions
 {
-    [Obsolete("Use the WorkstepUsage class instead")]
-    public class WorkstepDurationCalculation
+    public class WorkstepUsageCalculation
     {
-        [ForeignKey(typeof(WorkstepDuration))]
-        public Guid WorkstepDurationId { get; set; }
+        [ForeignKey(typeof(WorkstepUsage))]
+        public Guid WorkstepUsageId { get; set; }
 
         [ForeignKey(typeof(Calculation3d))]
         public Guid CalculationId { get; set; }

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/WorkstepAdditions/WorkstepUsageParameter.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/WorkstepAdditions/WorkstepUsageParameter.cs
@@ -1,0 +1,46 @@
+﻿using AndreasReitberger.Print3d.Enums;
+using AndreasReitberger.Print3d.Interfaces;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Newtonsoft.Json;
+using SQLite;
+using SQLiteNetExtensions.Attributes;
+
+namespace AndreasReitberger.Print3d.SQLite.WorkstepAdditions
+{
+    [Table($"{nameof(WorkstepUsageParameter)}s")]
+    public partial class WorkstepUsageParameter : ObservableObject, IWorkstepUsageParameter
+    {
+        #region Properties
+        [ObservableProperty]
+        [property: PrimaryKey]
+        Guid id;
+
+        [ObservableProperty]
+        WorkstepUsageParameterType parameterType = WorkstepUsageParameterType.Quantity;
+
+        [ObservableProperty]
+        double value = 0;
+        #endregion
+
+        #region Constructors
+        public WorkstepUsageParameter()
+        {
+            Id = Guid.NewGuid();
+        }
+        #endregion
+
+        #region Overrides
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
+        public override bool Equals(object obj)
+        {
+            if (obj is not WorkstepUsageParameter item)
+                return false;
+            return Id.Equals(item.Id);
+        }
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+        #endregion
+    }
+}

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/WorkstepUsage.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/WorkstepUsage.cs
@@ -1,0 +1,78 @@
+﻿using AndreasReitberger.Print3d.Interfaces;
+using AndreasReitberger.Print3d.SQLite.WorkstepAdditions;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Newtonsoft.Json;
+using SQLite;
+using SQLiteNetExtensions.Attributes;
+
+namespace AndreasReitberger.Print3d.SQLite
+{
+    [Table($"{nameof(WorkstepUsage)}s")]
+    public partial class WorkstepUsage : ObservableObject, IWorkstepUsage
+    {
+        #region Properties
+        [ObservableProperty]
+        [property: PrimaryKey]
+        Guid id;
+
+        [ObservableProperty]
+        [property: ForeignKey(typeof(Calculation3d))]
+        Guid calculationId;
+
+        [ObservableProperty]
+        Guid workstepId;
+
+        [ObservableProperty]
+        [property: ManyToOne(nameof(WorkstepId), CascadeOperations = CascadeOperation.All)]
+        Workstep workstep;
+        partial void OnWorkstepChanged(Workstep value) => TotalCosts = GetTotalCosts();
+
+        [ObservableProperty]
+        Guid usageParameterId;
+
+        [ObservableProperty]
+        [property: ManyToOne(nameof(UsageParameterId), CascadeOperations = CascadeOperation.All)]
+        WorkstepUsageParameter usageParameter;
+        partial void OnUsageParameterChanged(WorkstepUsageParameter value) => TotalCosts = GetTotalCosts();
+        
+        [ObservableProperty]
+        double totalCosts = 0;
+        #endregion
+
+        #region Constructors
+        public WorkstepUsage()
+        {
+            Id = Guid.NewGuid();
+        }
+        #endregion
+
+        #region Methods
+
+        public double GetTotalCosts()
+        {
+            double cost;
+            cost = (UsageParameter?.ParameterType) switch
+            {
+                Enums.WorkstepUsageParameterType.Duration => (Workstep?.Price * UsageParameter?.Value) ?? 0,
+                _ => (Workstep?.Price * UsageParameter?.Value) ?? 0,
+            };
+            return cost;
+        }
+
+        #endregion
+
+        #region Overrides
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
+        public override bool Equals(object obj)
+        {
+            if (obj is not WorkstepUsage item)
+                return false;
+            return Id.Equals(item.Id);
+        }
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+        #endregion
+    }
+}

--- a/source/3dPrintCalculatorLibrary/Enums/WorkstepUsageParameterType.cs
+++ b/source/3dPrintCalculatorLibrary/Enums/WorkstepUsageParameterType.cs
@@ -1,0 +1,8 @@
+﻿namespace AndreasReitberger.Print3d.Enums
+{
+    public enum WorkstepUsageParameterType
+    {
+        Duration,
+        Quantity,
+    }
+}

--- a/source/3dPrintCalculatorLibrary/Interfaces/IWorkstepUsage.cs
+++ b/source/3dPrintCalculatorLibrary/Interfaces/IWorkstepUsage.cs
@@ -2,13 +2,18 @@
 
 namespace AndreasReitberger.Print3d.Interfaces
 {
-    [Obsolete("Use the IWorkstepUsage class instead")]
-    public interface IWorkstepDuration
+    public interface IWorkstepUsage
     {
         #region Properties
         public Guid Id { get; set; }
         public Guid WorkstepId { get; set; }
-        public double Duration { get; set; }
+        public double TotalCosts { get; set; }
+        #endregion
+
+        #region Methods
+
+        public double GetTotalCosts();
+
         #endregion
     }
 }

--- a/source/3dPrintCalculatorLibrary/Interfaces/IWorkstepUsageParameter.cs
+++ b/source/3dPrintCalculatorLibrary/Interfaces/IWorkstepUsageParameter.cs
@@ -1,0 +1,14 @@
+﻿using AndreasReitberger.Print3d.Enums;
+using System;
+
+namespace AndreasReitberger.Print3d.Interfaces
+{
+    public interface IWorkstepUsageParameter
+    {
+        #region Properties
+        public Guid Id { get; set; }
+        public WorkstepUsageParameterType ParameterType { get; set; }
+        public double Value { get; set; }
+        #endregion
+    }
+}

--- a/source/3dPrintCalculatorLibrary/Models/Calculation3d.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Calculation3d.Extensions.cs
@@ -300,12 +300,32 @@ namespace AndreasReitberger.Print3d.Models
                 }
 
                 // Worksteps
+                // Delete once migrated to `WorkstepUsage` instead
                 if (WorkSteps?.Count > 0)
                 {
                     // Only take the worksteps, which are set as `PerPiece` here
                     foreach (Workstep ws in WorkSteps.Where(ws => ws.CalculationType == CalculationType.PerPiece))
                     {
                         double totalPerPiece = ws.TotalCosts * file.Quantity;
+                        Costs?.Add(new CalculationAttribute()
+                        {
+                            LinkedId = ws.Id,
+                            Attribute = ws.Name,
+                            Type = CalculationAttributeType.Workstep,
+                            Value = totalPerPiece,
+                            FileId = file.Id,
+                            FileName = file.FileName,
+                        });
+                    }
+                }
+                if (WorkstepUsages?.Count > 0)
+                {
+                    // Only take the worksteps, which are set as `PerPiece` here
+                    foreach (WorkstepUsage wsu in WorkstepUsages.Where(wsu => wsu?.Workstep?.CalculationType == CalculationType.PerPiece))
+                    {
+                        Workstep ws = wsu.Workstep;
+                        if (ws is null) continue;
+                        double totalPerPiece = wsu.TotalCosts * file.Quantity;
                         Costs?.Add(new CalculationAttribute()
                         {
                             LinkedId = ws.Id,
@@ -494,6 +514,7 @@ namespace AndreasReitberger.Print3d.Models
             }
 
             // Worksteps
+            // Delete once migrated to `WorkstepUsage` instead
             if (WorkSteps?.Count > 0)
             {
                 foreach (Workstep ws in WorkSteps.Where(ws => ws.CalculationType != CalculationType.PerPiece))
@@ -534,6 +555,22 @@ namespace AndreasReitberger.Print3d.Models
                             // Nothing to do here
                             break;
                     }
+                }
+            }
+            if (WorkstepUsages?.Count > 0)
+            {
+                foreach (WorkstepUsage wsu in WorkstepUsages.Where(wsu => wsu?.Workstep?.CalculationType != CalculationType.PerPiece))
+                {
+                    Workstep ws = wsu.Workstep;
+                    if (ws is null) continue;
+                    double totalPerJob = wsu.TotalCosts;
+                    Costs?.Add(new CalculationAttribute()
+                    {
+                        LinkedId = ws.Id,
+                        Attribute = ws.Name,
+                        Type = CalculationAttributeType.Workstep,
+                        Value = totalPerJob,
+                    });
                 }
             }
 

--- a/source/3dPrintCalculatorLibrary/Models/Calculation3d.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Calculation3d.cs
@@ -3,14 +3,12 @@ using AndreasReitberger.Print3d.Interfaces;
 using AndreasReitberger.Print3d.Models.CalculationAdditions;
 using AndreasReitberger.Print3d.Models.Events;
 using AndreasReitberger.Print3d.Models.WorkstepAdditions;
-using AndreasReitberger.Print3d.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
-using System.Linq;
 using System.Xml.Serialization;
 
 namespace AndreasReitberger.Print3d.Models
@@ -128,9 +126,14 @@ namespace AndreasReitberger.Print3d.Models
         List<CustomAddition> customAdditions = new();
 
         [ObservableProperty]
+        List<WorkstepUsage> workstepUsages = new();
+
+        [ObservableProperty]
+        [Obsolete("Use the WorkstepUsages class instead")]
         List<Workstep> workSteps = new();
 
         [ObservableProperty]
+        [Obsolete("Use the WorkstepUsages class instead")]
         List<WorkstepDuration> workStepDurations = new();
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary/Models/Calculation3dProfile.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Calculation3dProfile.cs
@@ -192,7 +192,7 @@ namespace AndreasReitberger.Print3d.Models
         ObservableCollection<IItem3dUsage> items = new();
 
         [ObservableProperty]
-        ObservableCollection<IWorkstep> worksteps = new();
+        ObservableCollection<IWorkstepUsage> worksteps = new();
         #endregion
 
         #endregion

--- a/source/3dPrintCalculatorLibrary/Models/Workstep.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Workstep.cs
@@ -26,6 +26,7 @@ namespace AndreasReitberger.Print3d.Models
         }
 
         [ObservableProperty]
+        [Obsolete("Use the WorkstepUsageParameter instead")]
         int quantity = 1;
         partial void OnQuantityChanged(int value)
         {
@@ -42,6 +43,7 @@ namespace AndreasReitberger.Print3d.Models
         CalculationType calculationType;
 
         [ObservableProperty]
+        [Obsolete("Use the WorkstepUsageParameter instead")]
         double duration = 0;
         partial void OnDurationChanged(double value)
         {
@@ -52,6 +54,7 @@ namespace AndreasReitberger.Print3d.Models
         WorkstepType type;
 
         [ObservableProperty]
+        [Obsolete("Use the WorkstepUsageParameter instead")]
         double totalCosts = 0;
 
         [ObservableProperty]
@@ -63,6 +66,7 @@ namespace AndreasReitberger.Print3d.Models
         #endregion
 
         #region Private
+        [Obsolete("Use the WorkstepUsageParameter instead")]
         double CalcualteTotalCosts()
         {
             try

--- a/source/3dPrintCalculatorLibrary/Models/WorkstepAdditions/WorstepUsageParameter.cs
+++ b/source/3dPrintCalculatorLibrary/Models/WorkstepAdditions/WorstepUsageParameter.cs
@@ -1,41 +1,36 @@
-﻿using AndreasReitberger.Print3d.Interfaces;
+﻿using AndreasReitberger.Print3d.Enums;
+using AndreasReitberger.Print3d.Interfaces;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Newtonsoft.Json;
 using System;
 
 namespace AndreasReitberger.Print3d.Models.WorkstepAdditions
 {
-    [Obsolete("Use the WorkstepUsage class instead")]
-    public partial class WorkstepDuration : ObservableObject, IWorkstepDuration
+    public partial class WorstepUsageParameter : ObservableObject, IWorkstepUsageParameter
     {
         #region Properties
         [ObservableProperty]
         Guid id;
 
         [ObservableProperty]
-        Workstep workstep;
+        WorkstepUsageParameterType parameterType = WorkstepUsageParameterType.Quantity;
 
         [ObservableProperty]
-        Guid workstepId;
-
-        [ObservableProperty]
-        double duration = 0;
+        double value = 0;
         #endregion
 
         #region Constructors
-        public WorkstepDuration()
+        public WorstepUsageParameter()
         {
             Id = Guid.NewGuid();
         }
         #endregion
 
         #region Overrides
-        public override string ToString()
-        {
-            return Duration.ToString();
-        }
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
         public override bool Equals(object obj)
         {
-            if (obj is not WorkstepDuration item)
+            if (obj is not WorstepUsageParameter item)
                 return false;
             return Id.Equals(item.Id);
         }

--- a/source/3dPrintCalculatorLibrary/Models/WorkstepUsage.cs
+++ b/source/3dPrintCalculatorLibrary/Models/WorkstepUsage.cs
@@ -1,0 +1,70 @@
+﻿using AndreasReitberger.Print3d.Interfaces;
+using AndreasReitberger.Print3d.Models.WorkstepAdditions;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Newtonsoft.Json;
+using System;
+
+namespace AndreasReitberger.Print3d.Models
+{
+    public partial class WorkstepUsage : ObservableObject, IWorkstepUsage
+    {
+        #region Properties
+        [ObservableProperty]
+        Guid id;
+
+        [ObservableProperty]
+        Guid calculationId;
+
+        [ObservableProperty]
+        Guid workstepId;
+
+        [ObservableProperty]
+        Workstep workstep;
+
+        [ObservableProperty]
+        Guid usageParameterId;
+
+        [ObservableProperty]
+        WorstepUsageParameter usageParameter;
+
+        [ObservableProperty]
+        double totalCosts = 0;
+
+        #endregion
+
+        #region Constructors
+        public WorkstepUsage()
+        {
+            Id = Guid.NewGuid();
+        }
+        #endregion
+
+        #region Methods
+        public double GetTotalCosts()
+        {
+            double cost;
+            cost = (UsageParameter?.ParameterType) switch
+            {
+                Enums.WorkstepUsageParameterType.Duration => (Workstep?.Price * UsageParameter?.Value) ?? 0,
+                _ => (Workstep?.Price * UsageParameter?.Value) ?? 0,
+            };
+            return cost;
+        }
+
+        #endregion
+
+        #region Overrides
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
+        public override bool Equals(object obj)
+        {
+            if (obj is not WorkstepUsage item)
+                return false;
+            return Id.Equals(item.Id);
+        }
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
This PR adds the `WorkstepUsage` class and its dependencies. This allows better handling of the paramters for each `WorkstepType`.

## Breaking Changes
The class `Workstep` will be changed in near future, at the moment, both ways are possible to avoid breaking existings app. It is recommended to switch to `WorkstepUsage` instead of using `WorkstepDuration`. Later will be removed in an upcoming release.

Fixed #80