### PR TITLE
Replaced returing `ObservableCollection<T>` with `List<T>`

### DIFF
--- a/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3d.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3d.cs
@@ -11,6 +11,7 @@ using ErrorEventArgs = System.IO.ErrorEventArgs;
 
 namespace AndreasReitberger.Print3d.Realm
 {
+    [Obsolete("Use Calculation3dEnhanced instead")]
     public partial class Calculation3d : RealmObject, ICalculation3d, ICloneable
     {
 

--- a/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3dEnhanced.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3dEnhanced.cs
@@ -22,6 +22,13 @@ namespace AndreasReitberger.Print3d.Realm
         [Required]
         public string Name { get; set; } = string.Empty;
 
+        public CalculationState State
+        {
+            get => (CalculationState)StateId;
+            set { StateId = (int)value; }
+        }
+        public int StateId { get; set; } = (int)CalculationState.Draft;
+
         public DateTimeOffset Created { get; set; } = DateTime.Now;
 
         public Guid CustomerId { get; set; }

--- a/source/3dPrintCalculatorLibrary.Realm/PrintCalculator3d.Calculation3d.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/PrintCalculator3d.Calculation3d.cs
@@ -1,18 +1,19 @@
 ﻿using AndreasReitberger.Print3d.Enums;
-using AndreasReitberger.Print3d.Models;
 using AndreasReitberger.Print3d.Utilities;
-using System.Collections.ObjectModel;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace AndreasReitberger.Print3d.Realm
 {
-    public static class PrintCalculator3d
+    public static partial class PrintCalculator3d
     {
         #region Public
-        public static ObservableCollection<Calculation3dChartItem> GetCosts(Calculation3d calculation)
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetCosts(Calculation3d calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var Costs = new ObservableCollection<Calculation3dChartItem>(
+            if (!calculation.IsCalculated) return [];
+            var Costs = new List<Calculation3dChartItem>(
                 calculation.Costs.Select(cost => new Calculation3dChartItem()
                 {
                     Name = cost.Attribute,
@@ -23,10 +24,11 @@ namespace AndreasReitberger.Print3d.Realm
                 }));
             return Costs;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetMaterialUsage(Calculation3d calculation)
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetMaterialUsage(Calculation3d calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var MaterialUsage = new ObservableCollection<Calculation3dChartItem>(
+            if (!calculation.IsCalculated) return [];
+            var MaterialUsage = new List<Calculation3dChartItem>(
                 calculation.MaterialUsage.Select(cost => new Calculation3dChartItem()
                 {
                     Name = cost.Attribute,
@@ -37,10 +39,11 @@ namespace AndreasReitberger.Print3d.Realm
                 }));
             return MaterialUsage;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetMachineCosts(Calculation3d calculation)
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetMachineCosts(Calculation3d calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var MachineCosts = new ObservableCollection<Calculation3dChartItem>(calculation.OverallPrinterCosts
+            if (!calculation.IsCalculated) return [];
+            var MachineCosts = new List<Calculation3dChartItem>(calculation.OverallPrinterCosts
                 .Where(cost => (
                     cost.Type == CalculationAttributeType.Machine ||
                     cost.Type == CalculationAttributeType.Energy ||
@@ -57,10 +60,11 @@ namespace AndreasReitberger.Print3d.Realm
                 }));
             return MachineCosts;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetMaterialCosts(Calculation3d calculation)
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetMaterialCosts(Calculation3d calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var MaterialCosts = new ObservableCollection<Calculation3dChartItem>(calculation.OverallMaterialCosts
+            if (!calculation.IsCalculated) return [];
+            var MaterialCosts = new List<Calculation3dChartItem>(calculation.OverallMaterialCosts
                 .Where(cost => (
                     cost.Type == CalculationAttributeType.Material ||
                     cost.Type == CalculationAttributeType.ProcedureSpecificAddition) &&
@@ -75,10 +79,11 @@ namespace AndreasReitberger.Print3d.Realm
                 }));
             return MaterialCosts;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetWorkstepCosts(Calculation3d calculation)
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetWorkstepCosts(Calculation3d calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var WorkstepCosts = new ObservableCollection<Calculation3dChartItem>(calculation.Costs
+            if (!calculation.IsCalculated) return [];
+            var WorkstepCosts = new List<Calculation3dChartItem>(calculation.Costs
                 .Where(cost =>
                     cost.Type == CalculationAttributeType.Workstep ||
                     cost.Type == CalculationAttributeType.ProcedureSpecificAddition)
@@ -92,10 +97,11 @@ namespace AndreasReitberger.Print3d.Realm
                 }));
             return WorkstepCosts;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetCustomAdditionsCosts(Calculation3d calculation)
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetCustomAdditionsCosts(Calculation3d calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var WorkstepCosts = new ObservableCollection<Calculation3dChartItem>(calculation.Costs
+            if (!calculation.IsCalculated) return [];
+            var WorkstepCosts = new List<Calculation3dChartItem>(calculation.Costs
                 .Where(cost => cost.Type == CalculationAttributeType.CustomAddition)
                 .Select(cost => new Calculation3dChartItem()
                 {
@@ -107,10 +113,11 @@ namespace AndreasReitberger.Print3d.Realm
                 }));
             return WorkstepCosts;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetRatesCosts(Calculation3d calculation)
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetRatesCosts(Calculation3d calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var RatesCosts = new ObservableCollection<Calculation3dChartItem>(calculation.Costs
+            if (!calculation.IsCalculated) return [];
+            var RatesCosts = new List<Calculation3dChartItem>(calculation.Costs
                 .Where(cost => cost.Type == CalculationAttributeType.Margin || cost.Type == CalculationAttributeType.Tax || cost.Type == CalculationAttributeType.CustomAddition)
                 .Select(cost => new Calculation3dChartItem()
                 {

--- a/source/3dPrintCalculatorLibrary.Realm/PrintCalculator3d.Calculation3dEnhanced.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/PrintCalculator3d.Calculation3dEnhanced.cs
@@ -1,88 +1,82 @@
 ﻿using AndreasReitberger.Print3d.Enums;
-using AndreasReitberger.Print3d.Models;
 using AndreasReitberger.Print3d.Utilities;
-using System.Collections.ObjectModel;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 
-namespace AndreasReitberger.Print3d
+namespace AndreasReitberger.Print3d.Realm
 {
-    public static class PrintCalculator3d
+    public static partial class PrintCalculator3d
     {
         #region Public
-        public static ObservableCollection<Calculation3dChartItem> GetCosts(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetCosts(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var Costs = new ObservableCollection<Calculation3dChartItem>(
+            if (!calculation.IsCalculated) return [];
+            var Costs = new List<Calculation3dChartItem>(
                 calculation.Costs.Select(cost => new Calculation3dChartItem()
                 {
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
-                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
             return Costs;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetMaterialUsage(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetMaterialUsage(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var MaterialUsage = new ObservableCollection<Calculation3dChartItem>(
+            if (!calculation.IsCalculated) return [];
+            var MaterialUsage = new List<Calculation3dChartItem>(
                 calculation.MaterialUsage.Select(cost => new Calculation3dChartItem()
                 {
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
-                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
             return MaterialUsage;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetMachineCosts(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetMachineCosts(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var MachineCosts = new ObservableCollection<Calculation3dChartItem>(calculation.OverallPrinterCosts
+            if (!calculation.IsCalculated) return [];
+            var MachineCosts = new List<Calculation3dChartItem>(calculation.OverallPrinterCosts
                 .Where(cost => (
                     cost.Type == CalculationAttributeType.Machine ||
                     cost.Type == CalculationAttributeType.Energy ||
-                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition) &&
-                (cost.LinkedId == calculation.Printer.Id || cost.Attribute == calculation.Printer.Name)
+                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition)
                 )
                 .Select(cost => new Calculation3dChartItem()
                 {
                     Name = calculation.DifferFileCosts ? $"{cost.Attribute} ({cost.FileName})" : cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
-                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
             return MachineCosts;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetMaterialCosts(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetMaterialCosts(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var MaterialCosts = new ObservableCollection<Calculation3dChartItem>(calculation.OverallMaterialCosts
+            if (!calculation.IsCalculated) return [];
+            var MaterialCosts = new List<Calculation3dChartItem>(calculation.OverallMaterialCosts
                 .Where(cost => (
                     cost.Type == CalculationAttributeType.Material ||
-                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition) &&
-                (calculation.CombineMaterialCosts || (cost.LinkedId == calculation.Material.Id || cost.Attribute == calculation.Material.Name)))
+                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition))
                 .Select(cost => new Calculation3dChartItem()
                 {
                     Name = calculation.DifferFileCosts ? $"{cost.Attribute} ({cost.FileName})" : cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
-                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
             return MaterialCosts;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetWorkstepCosts(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetWorkstepCosts(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var WorkstepCosts = new ObservableCollection<Calculation3dChartItem>(calculation.Costs
+            if (!calculation.IsCalculated) return [];
+            var WorkstepCosts = new List<Calculation3dChartItem>(calculation.Costs
                 .Where(cost =>
                     cost.Type == CalculationAttributeType.Workstep ||
                     cost.Type == CalculationAttributeType.ProcedureSpecificAddition)
@@ -91,39 +85,36 @@ namespace AndreasReitberger.Print3d
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
-                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
             return WorkstepCosts;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetCustomAdditionsCosts(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetCustomAdditionsCosts(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var WorkstepCosts = new ObservableCollection<Calculation3dChartItem>(calculation.Costs
+            if (!calculation.IsCalculated) return [];
+            var WorkstepCosts = new List<Calculation3dChartItem>(calculation.Costs
                 .Where(cost => cost.Type == CalculationAttributeType.CustomAddition)
                 .Select(cost => new Calculation3dChartItem()
                 {
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
-                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));
             return WorkstepCosts;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetRatesCosts(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetRatesCosts(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var RatesCosts = new ObservableCollection<Calculation3dChartItem>(calculation.Costs
+            if (!calculation.IsCalculated) return [];
+            var RatesCosts = new List<Calculation3dChartItem>(calculation.Costs
                 .Where(cost => cost.Type == CalculationAttributeType.Margin || cost.Type == CalculationAttributeType.Tax || cost.Type == CalculationAttributeType.CustomAddition)
                 .Select(cost => new Calculation3dChartItem()
                 {
                     Name = cost.Attribute,
                     Value = cost.Value,
                     AttributeType = cost.Type,
-                    AttributeItem = cost.Item,
                     FileId = cost.FileId,
                     FileName = cost.FileName,
                 }));

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3dEnhanced.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3dEnhanced.cs
@@ -35,6 +35,9 @@ namespace AndreasReitberger.Print3d.SQLite
         string name = string.Empty;
 
         [ObservableProperty]
+        CalculationState state = CalculationState.Draft;
+
+        [ObservableProperty]
         DateTimeOffset created = DateTime.Now;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary.SQLite/PrintCalculator3d.Calculation3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/PrintCalculator3d.Calculation3d.cs
@@ -1,0 +1,156 @@
+﻿using AndreasReitberger.Print3d.Enums;
+using AndreasReitberger.Print3d.Utilities;
+
+namespace AndreasReitberger.Print3d.SQLite
+{
+    public static partial class PrintCalculator3d
+    {
+        #region Public
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetCosts(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(
+                calculation.Costs.Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return costs;
+        }
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetMaterialUsage(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var usage = new List<Calculation3dChartItem>(
+                calculation.MaterialUsage.Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return usage;
+        }
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetMachineCosts(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(calculation.OverallPrinterCosts
+                .Where(cost => (
+                    cost.Type == CalculationAttributeType.Machine ||
+                    cost.Type == CalculationAttributeType.Energy ||
+                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition) &&
+                (cost.LinkedId == calculation.Printer.Id || cost.Attribute == calculation.Printer.Name)
+                )
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = calculation.DifferFileCosts ? $"{cost.Attribute} ({cost.FileName})" : cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return costs;
+        }
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetMaterialCosts(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(calculation.OverallMaterialCosts
+                .Where(cost => (
+                    cost.Type == CalculationAttributeType.Material ||
+                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition) &&
+                (calculation.CombineMaterialCosts || (cost.LinkedId == calculation.Material.Id || cost.Attribute == calculation.Material.Name)))
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = calculation.DifferFileCosts ? $"{cost.Attribute} ({cost.FileName})" : cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return costs;
+        }
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetItemCosts(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(calculation.Costs
+                .Where(cost => (
+                    cost.Type == CalculationAttributeType.AdditionalItem))
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return costs;
+        }
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetWorkstepCosts(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(calculation.Costs
+                .Where(cost =>
+                    cost.Type == CalculationAttributeType.Workstep ||
+                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition)
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return costs;
+        }
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetCustomAdditionsCosts(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(calculation.Costs
+                .Where(cost => cost.Type == CalculationAttributeType.CustomAddition)
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return costs;
+        }
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetRatesCosts(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(calculation.Costs
+                .Where(cost => cost.Type == CalculationAttributeType.Margin || cost.Type == CalculationAttributeType.Tax || cost.Type == CalculationAttributeType.CustomAddition)
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return costs;
+        }
+        #endregion
+    }
+}

--- a/source/3dPrintCalculatorLibrary.SQLite/PrintCalculator3d.Calculation3dEnhanced.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/PrintCalculator3d.Calculation3dEnhanced.cs
@@ -1,18 +1,15 @@
 ﻿using AndreasReitberger.Print3d.Enums;
-using AndreasReitberger.Print3d.SQLite;
 using AndreasReitberger.Print3d.Utilities;
-using System.Collections.ObjectModel;
-using System.Linq;
 
 namespace AndreasReitberger.Print3d.SQLite
 {
-    public static class PrintCalculator3d
+    public static partial class PrintCalculator3d
     {
         #region Public
-        public static ObservableCollection<Calculation3dChartItem> GetCosts(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetCosts(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var costs = new ObservableCollection<Calculation3dChartItem>(
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(
                 calculation.Costs.Select(cost => new Calculation3dChartItem()
                 {
                     Name = cost.Attribute,
@@ -24,10 +21,10 @@ namespace AndreasReitberger.Print3d.SQLite
                 }));
             return costs;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetMaterialUsage(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetMaterialUsage(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var usage = new ObservableCollection<Calculation3dChartItem>(
+            if (!calculation.IsCalculated) return [];
+            var usage = new List<Calculation3dChartItem>(
                 calculation.MaterialUsage.Select(cost => new Calculation3dChartItem()
                 {
                     Name = cost.Attribute,
@@ -39,15 +36,14 @@ namespace AndreasReitberger.Print3d.SQLite
                 }));
             return usage;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetMachineCosts(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetMachineCosts(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var costs = new ObservableCollection<Calculation3dChartItem>(calculation.OverallPrinterCosts
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(calculation.OverallPrinterCosts
                 .Where(cost => (
                     cost.Type == CalculationAttributeType.Machine ||
                     cost.Type == CalculationAttributeType.Energy ||
-                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition) &&
-                (cost.LinkedId == calculation.Printer.Id || cost.Attribute == calculation.Printer.Name)
+                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition)
                 )
                 .Select(cost => new Calculation3dChartItem()
                 {
@@ -60,14 +56,13 @@ namespace AndreasReitberger.Print3d.SQLite
                 }));
             return costs;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetMaterialCosts(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetMaterialCosts(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var costs = new ObservableCollection<Calculation3dChartItem>(calculation.OverallMaterialCosts
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(calculation.OverallMaterialCosts
                 .Where(cost => (
                     cost.Type == CalculationAttributeType.Material ||
-                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition) &&
-                (calculation.CombineMaterialCosts || (cost.LinkedId == calculation.Material.Id || cost.Attribute == calculation.Material.Name)))
+                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition))
                 .Select(cost => new Calculation3dChartItem()
                 {
                     Name = calculation.DifferFileCosts ? $"{cost.Attribute} ({cost.FileName})" : cost.Attribute,
@@ -79,10 +74,10 @@ namespace AndreasReitberger.Print3d.SQLite
                 }));
             return costs;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetItemCosts(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetItemCosts(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var costs = new ObservableCollection<Calculation3dChartItem>(calculation.Costs
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(calculation.Costs
                 .Where(cost => (
                     cost.Type == CalculationAttributeType.AdditionalItem))
                 .Select(cost => new Calculation3dChartItem()
@@ -96,10 +91,10 @@ namespace AndreasReitberger.Print3d.SQLite
                 }));
             return costs;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetWorkstepCosts(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetWorkstepCosts(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var costs = new ObservableCollection<Calculation3dChartItem>(calculation.Costs
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(calculation.Costs
                 .Where(cost =>
                     cost.Type == CalculationAttributeType.Workstep ||
                     cost.Type == CalculationAttributeType.ProcedureSpecificAddition)
@@ -114,10 +109,10 @@ namespace AndreasReitberger.Print3d.SQLite
                 }));
             return costs;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetCustomAdditionsCosts(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetCustomAdditionsCosts(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var costs = new ObservableCollection<Calculation3dChartItem>(calculation.Costs
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(calculation.Costs
                 .Where(cost => cost.Type == CalculationAttributeType.CustomAddition)
                 .Select(cost => new Calculation3dChartItem()
                 {
@@ -130,10 +125,10 @@ namespace AndreasReitberger.Print3d.SQLite
                 }));
             return costs;
         }
-        public static ObservableCollection<Calculation3dChartItem> GetRatesCosts(Calculation3d calculation)
+        public static List<Calculation3dChartItem> GetRatesCosts(Calculation3dEnhanced calculation)
         {
-            if (!calculation.IsCalculated) return new ObservableCollection<Calculation3dChartItem>();
-            var costs = new ObservableCollection<Calculation3dChartItem>(calculation.Costs
+            if (!calculation.IsCalculated) return [];
+            var costs = new List<Calculation3dChartItem>(calculation.Costs
                 .Where(cost => cost.Type == CalculationAttributeType.Margin || cost.Type == CalculationAttributeType.Tax || cost.Type == CalculationAttributeType.CustomAddition)
                 .Select(cost => new Calculation3dChartItem()
                 {

--- a/source/3dPrintCalculatorLibrary/Interfaces/ICalculation3dEnhanced.cs
+++ b/source/3dPrintCalculatorLibrary/Interfaces/ICalculation3dEnhanced.cs
@@ -11,6 +11,7 @@ namespace AndreasReitberger.Print3d.Interfaces
 
         #region Basics
         string Name { get; set; }
+        CalculationState State { get; set; }
         DateTimeOffset Created { get; set; }
         public Guid CustomerId { get; set; }
         //ICustomer3d Customer { get; set; }

--- a/source/3dPrintCalculatorLibrary/Models/Calculation3dEnhanced.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Calculation3dEnhanced.cs
@@ -31,6 +31,9 @@ namespace AndreasReitberger.Print3d.Models
         string name = string.Empty;
 
         [ObservableProperty]
+        CalculationState state = CalculationState.Draft;
+
+        [ObservableProperty]
         DateTimeOffset created = DateTime.Now;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary/PrintCalculator3d.Calculation3d.cs
+++ b/source/3dPrintCalculatorLibrary/PrintCalculator3d.Calculation3d.cs
@@ -1,0 +1,142 @@
+﻿using AndreasReitberger.Print3d.Enums;
+using AndreasReitberger.Print3d.Models;
+using AndreasReitberger.Print3d.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AndreasReitberger.Print3d
+{
+    public static partial class PrintCalculator3d
+    {
+        #region Public
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetCosts(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var Costs = new List<Calculation3dChartItem>(
+                calculation.Costs.Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return Costs;
+        }
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetMaterialUsage(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var MaterialUsage = new List<Calculation3dChartItem>(
+                calculation.MaterialUsage.Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return MaterialUsage;
+        }
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetMachineCosts(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var MachineCosts = new List<Calculation3dChartItem>(calculation.OverallPrinterCosts
+                .Where(cost => (
+                    cost.Type == CalculationAttributeType.Machine ||
+                    cost.Type == CalculationAttributeType.Energy ||
+                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition) &&
+                (cost.LinkedId == calculation.Printer.Id || cost.Attribute == calculation.Printer.Name)
+                )
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = calculation.DifferFileCosts ? $"{cost.Attribute} ({cost.FileName})" : cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return MachineCosts;
+        }
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetMaterialCosts(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var MaterialCosts = new List<Calculation3dChartItem>(calculation.OverallMaterialCosts
+                .Where(cost => (
+                    cost.Type == CalculationAttributeType.Material ||
+                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition) &&
+                (calculation.CombineMaterialCosts || (cost.LinkedId == calculation.Material.Id || cost.Attribute == calculation.Material.Name)))
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = calculation.DifferFileCosts ? $"{cost.Attribute} ({cost.FileName})" : cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return MaterialCosts;
+        }
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetWorkstepCosts(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var WorkstepCosts = new List<Calculation3dChartItem>(calculation.Costs
+                .Where(cost =>
+                    cost.Type == CalculationAttributeType.Workstep ||
+                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition)
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return WorkstepCosts;
+        }
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetCustomAdditionsCosts(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var WorkstepCosts = new List<Calculation3dChartItem>(calculation.Costs
+                .Where(cost => cost.Type == CalculationAttributeType.CustomAddition)
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return WorkstepCosts;
+        }
+        [Obsolete("Will be replaced with Calculation3dEnhanced")]
+        public static List<Calculation3dChartItem> GetRatesCosts(Calculation3d calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var RatesCosts = new List<Calculation3dChartItem>(calculation.Costs
+                .Where(cost => cost.Type == CalculationAttributeType.Margin || cost.Type == CalculationAttributeType.Tax || cost.Type == CalculationAttributeType.CustomAddition)
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return RatesCosts;
+        }
+        #endregion
+    }
+}

--- a/source/3dPrintCalculatorLibrary/PrintCalculator3d.Calculation3dEnhanced.cs
+++ b/source/3dPrintCalculatorLibrary/PrintCalculator3d.Calculation3dEnhanced.cs
@@ -1,0 +1,132 @@
+﻿using AndreasReitberger.Print3d.Enums;
+using AndreasReitberger.Print3d.Models;
+using AndreasReitberger.Print3d.Utilities;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AndreasReitberger.Print3d
+{
+    public static partial class PrintCalculator3d
+    {
+        #region Public
+        public static List<Calculation3dChartItem> GetCosts(Calculation3dEnhanced calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var Costs = new List<Calculation3dChartItem>(
+                calculation.Costs.Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return Costs;
+        }
+        public static List<Calculation3dChartItem> GetMaterialUsage(Calculation3dEnhanced calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var MaterialUsage = new List<Calculation3dChartItem>(
+                calculation.MaterialUsage.Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return MaterialUsage;
+        }
+        public static List<Calculation3dChartItem> GetMachineCosts(Calculation3dEnhanced calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var MachineCosts = new List<Calculation3dChartItem>(calculation.OverallPrinterCosts
+                .Where(cost => (
+                    cost.Type == CalculationAttributeType.Machine ||
+                    cost.Type == CalculationAttributeType.Energy ||
+                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition)
+                )
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = calculation.DifferFileCosts ? $"{cost.Attribute} ({cost.FileName})" : cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return MachineCosts;
+        }
+        public static List<Calculation3dChartItem> GetMaterialCosts(Calculation3dEnhanced calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var MaterialCosts = new List<Calculation3dChartItem>(calculation.OverallMaterialCosts
+                .Where(cost => (
+                    cost.Type == CalculationAttributeType.Material ||
+                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition))
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = calculation.DifferFileCosts ? $"{cost.Attribute} ({cost.FileName})" : cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return MaterialCosts;
+        }
+        public static List<Calculation3dChartItem> GetWorkstepCosts(Calculation3dEnhanced calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var WorkstepCosts = new List<Calculation3dChartItem>(calculation.Costs
+                .Where(cost =>
+                    cost.Type == CalculationAttributeType.Workstep ||
+                    cost.Type == CalculationAttributeType.ProcedureSpecificAddition)
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return WorkstepCosts;
+        }
+        public static List<Calculation3dChartItem> GetCustomAdditionsCosts(Calculation3dEnhanced calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var WorkstepCosts = new List<Calculation3dChartItem>(calculation.Costs
+                .Where(cost => cost.Type == CalculationAttributeType.CustomAddition)
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return WorkstepCosts;
+        }
+        public static List<Calculation3dChartItem> GetRatesCosts(Calculation3dEnhanced calculation)
+        {
+            if (!calculation.IsCalculated) return [];
+            var RatesCosts = new List<Calculation3dChartItem>(calculation.Costs
+                .Where(cost => cost.Type == CalculationAttributeType.Margin || cost.Type == CalculationAttributeType.Tax || cost.Type == CalculationAttributeType.CustomAddition)
+                .Select(cost => new Calculation3dChartItem()
+                {
+                    Name = cost.Attribute,
+                    Value = cost.Value,
+                    AttributeType = cost.Type,
+                    AttributeItem = cost.Item,
+                    FileId = cost.FileId,
+                    FileName = cost.FileName,
+                }));
+            return RatesCosts;
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
This PR replaces all returing `ObservableCollection<T>` with `List<T>` data types.

Fixed #97