### PR TITLE
Updated `Storage3dItem` to hold its `Storage3dTransactions`

### DIFF
--- a/source/3dPrintCalculatorLibrary.Core/Interfaces/IStorage3dItem.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Interfaces/IStorage3dItem.cs
@@ -6,7 +6,12 @@
         public Guid Id { get; set; }    
         public string Name { get; set; }
         public IMaterial3d Material { get; set; }
-        public double Amount { get; set; }
+        public IList<IStorage3dTransaction> Transactions { get; set; }
+        public double Amount { get; }
+        #endregion
+
+        #region Methods
+        public double GetAvailableAmount();
         #endregion
     }
 }

--- a/source/3dPrintCalculatorLibrary.Core/Interfaces/IStorage3dLocation.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Interfaces/IStorage3dLocation.cs
@@ -17,7 +17,7 @@ namespace AndreasReitberger.Print3d.Core.Interfaces
 
         public IStorage3dItem CreateStockItem(IMaterial3d material, double amount = 0, Unit unit = Unit.Kilogram);
         public void AddToStock(IStorage3dItem item, double amount, Unit unit);
-        public void AddToStock(IMaterial3d material, double amount, Unit unit);
+        public IStorage3dTransaction AddToStock(IMaterial3d material, double amount, Unit unit);
         public IStorage3dTransaction AddToStock(IMaterial3d material, double amount, Unit unit, Guid? calculationId = null);
         public bool TakeFromStock(IStorage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false);
         public bool TakeFromStock(IMaterial3d material, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false);

--- a/source/3dPrintCalculatorLibrary.Core/Models/Storage3d.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Models/Storage3d.cs
@@ -41,19 +41,25 @@ namespace AndreasReitberger.Print3d.Core
 
         public void AddToStock(IStorage3dLocation location, IStorage3dItem item, double amount, Unit unit)
         {
-            if (item?.Material != null)
+            if (item?.Material is not null)
             {
+                IStorage3dTransaction transaction = new Storage3dTransaction()
+                {
+                    DateTime = DateTimeOffset.Now,
+                    Unit = unit,
+                };
                 if (item?.Material.Unit == unit)
                 {
-                    item.Amount += amount;
+                    transaction.Amount += amount;
                 }
                 else
                 {
                     int target = UnitFactor.GetUnitFactor(item.Material.Unit);
                     int current = UnitFactor.GetUnitFactor(unit);
 
-                    item.Amount += target > current ? amount / (target / current) : amount * (current / target);
+                    transaction.Amount += target > current ? amount / (target / current) : amount * (current / target);
                 }
+                item.Transactions?.Add(transaction);
             }
         }
         public void AddToStock(IStorage3dLocation location, IMaterial3d material, double amount, Unit unit)
@@ -65,39 +71,39 @@ namespace AndreasReitberger.Print3d.Core
                 CreateStockItem(location: location, material, amount, unit);
         }
 
-        public IStorage3dTransaction AddToStock(IStorage3dLocation location, IMaterial3d material, double amount, Unit unit, Guid? calculationId = null)
+        public IStorage3dTransaction? AddToStock(IStorage3dLocation location, IMaterial3d material, double amount, Unit unit, Guid? calculationId = null)
         {
-            IStorage3dItem item = location?.Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            IStorage3dItem? item = location?.Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (item?.Material != null)
                 AddToStock(location: location, item: item, amount: amount, unit: unit);
             else
                 item = CreateStockItem(location: location, material, amount, unit);
-            return new Storage3dTransaction()
-            {
-                Amount = amount,
-                Unit = unit,
-                DateTime = DateTime.Now,
-                Item = item,
-            };
+            return item?.Transactions.LastOrDefault();
         }
 
         public bool TakeFromStock(IStorage3dLocation location, IStorage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
-            if (item?.Material != null)
+            if (item?.Material is not null)
             {
-                if (item.Amount >= amount)
+                IStorage3dTransaction transaction = new Storage3dTransaction()
                 {
-                    if (item?.Material.Unit == unit)
-                    {
-                        item.Amount -= amount;
-                    }
-                    else
-                    {
-                        int target = UnitFactor.GetUnitFactor(item.Material.Unit);
-                        int current = UnitFactor.GetUnitFactor(unit);
+                    DateTime = DateTimeOffset.Now,
+                    Unit = unit,
+                };
+                if (item?.Material.Unit == unit)
+                {
+                    transaction.Amount -= amount;
+                }
+                else
+                {
+                    int target = UnitFactor.GetUnitFactor(item.Material.Unit);
+                    int current = UnitFactor.GetUnitFactor(unit);
 
-                        item.Amount -= target > current ? amount / (target / current) : amount * (current / target);
-                    }
+                    transaction.Amount -= target > current ? amount / (target / current) : amount * (current / target);
+                }
+                if (item?.Amount + transaction.Amount >= 0)
+                {
+                    item?.Transactions.Add(transaction);
                     return true;
                 }
                 else if (throwIfMaterialIsNotInStock)
@@ -115,22 +121,16 @@ namespace AndreasReitberger.Print3d.Core
 
         public bool TakeFromStock(IStorage3dLocation location, IMaterial3d material, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
-            IStorage3dItem item = location?.Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            IStorage3dItem? item = location?.Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             return TakeFromStock(location: location, item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock);
         }
 
-        public IStorage3dTransaction TakeFromStock(IStorage3dLocation location, IMaterial3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
+        public IStorage3dTransaction? TakeFromStock(IStorage3dLocation location, IMaterial3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
         {
-            IStorage3dItem item = location?.Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            IStorage3dItem? item = location?.Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (TakeFromStock(location: location, item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock))
             {
-                return new Storage3dTransaction()
-                {
-                    Amount = -amount,
-                    Unit = unit,
-                    DateTime = DateTime.Now,
-                    Item = item,
-                };
+                return item?.Transactions.LastOrDefault();
             }
             else return null;
         }

--- a/source/3dPrintCalculatorLibrary.Core/Models/Storage3dItem.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Models/Storage3dItem.cs
@@ -16,7 +16,10 @@ namespace AndreasReitberger.Print3d.Core
         IMaterial3d? material;
 
         [ObservableProperty]
-        double amount;
+        [NotifyPropertyChangedFor(nameof(Amount))]
+        IList<IStorage3dTransaction> transactions = [];
+
+        public double Amount => GetAvailableAmount();
         #endregion
 
         #region Ctor
@@ -24,6 +27,11 @@ namespace AndreasReitberger.Print3d.Core
         {
             Id = Guid.NewGuid();
         }
+        #endregion
+
+        #region Methods
+        public double GetAvailableAmount() => Transactions?.Select(x => x.Amount).Sum() ?? 0;
+        
         #endregion
     }
 }

--- a/source/3dPrintCalculatorLibrary.Core/Models/Storage3dLocation.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Models/Storage3dLocation.cs
@@ -40,63 +40,70 @@ namespace AndreasReitberger.Print3d.Core
 
         public void AddToStock(IStorage3dItem item, double amount, Unit unit)
         {
-            if (item?.Material != null)
+            if (item?.Material is not null)
             {
+                IStorage3dTransaction transaction = new Storage3dTransaction()
+                {
+                    DateTime = DateTimeOffset.Now,
+                    Unit = unit,
+                };
                 if (item?.Material.Unit == unit)
                 {
-                    item.Amount += amount;
+                    transaction.Amount += amount;
                 }
                 else
                 {
                     int target = UnitFactor.GetUnitFactor(item.Material.Unit);
                     int current = UnitFactor.GetUnitFactor(unit);
 
-                    item.Amount += target > current ? amount / (target / current) : amount * (current / target);
+                    transaction.Amount += target > current ? amount / (target / current) : amount * (current / target);
                 }
+                item.Transactions.Add(transaction);
             }
         }
-        public void AddToStock(IMaterial3d material, double amount, Unit unit)
+        public IStorage3dTransaction? AddToStock(IMaterial3d material, double amount, Unit unit)
         {
-            IStorage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            IStorage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (item?.Material != null)
                 AddToStock(item: item, amount: amount, unit: unit);
             else
                 CreateStockItem(material, amount, unit);
+            return item?.Transactions.LastOrDefault();
         }
 
-        public IStorage3dTransaction AddToStock(IMaterial3d material, double amount, Unit unit, Guid? calculationId = null)
+        public IStorage3dTransaction? AddToStock(IMaterial3d material, double amount, Unit unit, Guid? calculationId = null)
         {
-            IStorage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            IStorage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (item?.Material != null)
                 AddToStock(item: item, amount: amount, unit: unit);
             else
                 item = CreateStockItem(material, amount, unit);
-            return new Storage3dTransaction()
-            {
-                Amount = amount,
-                Unit = unit,
-                DateTime = DateTime.Now,
-                Item = item,
-            };
+            return item?.Transactions.LastOrDefault();
         }
 
         public bool TakeFromStock(IStorage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
-            if (item?.Material != null)
+            if (item?.Material is not null)
             {
-                if (item.Amount >= amount)
+                IStorage3dTransaction transaction = new Storage3dTransaction()
                 {
-                    if (item?.Material.Unit == unit)
-                    {
-                        item.Amount -= amount;
-                    }
-                    else
-                    {
-                        int target = UnitFactor.GetUnitFactor(item.Material.Unit);
-                        int current = UnitFactor.GetUnitFactor(unit);
+                    DateTime = DateTimeOffset.Now,
+                    Unit = unit,
+                };
+                if (item?.Material.Unit == unit)
+                {
+                    transaction.Amount -= amount;
+                }
+                else
+                {
+                    int target = UnitFactor.GetUnitFactor(item.Material.Unit);
+                    int current = UnitFactor.GetUnitFactor(unit);
 
-                        item.Amount -= target > current ? amount / (target / current) : amount * (current / target);
-                    }
+                    transaction.Amount -= target > current ? amount / (target / current) : amount * (current / target);
+                }
+                if (item?.Amount + transaction.Amount >= 0)
+                {
+                    item?.Transactions.Add(transaction);
                     return true;
                 }
                 else if (throwIfMaterialIsNotInStock)
@@ -114,22 +121,16 @@ namespace AndreasReitberger.Print3d.Core
 
         public bool TakeFromStock(IMaterial3d material, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
-            IStorage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            IStorage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             return TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock);
         }
 
-        public IStorage3dTransaction TakeFromStock(IMaterial3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
+        public IStorage3dTransaction? TakeFromStock(IMaterial3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
         {
-            IStorage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            IStorage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock))
             {
-                return new Storage3dTransaction()
-                {
-                    Amount = -amount,
-                    Unit = unit,
-                    DateTime = DateTime.Now,
-                    Item = item,
-                };
+                return item?.Transactions.LastOrDefault();
             }
             else return null;
         }

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Core.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Core.cs
@@ -319,7 +319,7 @@ namespace AndreasReitberger.NUnitTest
         {
             try
             {
-                double startAmount = 2.68;
+                double startAmount = 0;
                 IMaterial3d material = new Material3d()
                 {
                     Name = "Test",
@@ -332,7 +332,6 @@ namespace AndreasReitberger.NUnitTest
                 IStorage3dItem item = new Storage3dItem()
                 {
                     Material = material,
-                    Amount = startAmount,
                 };
 
                 IStorage3dLocation location = new Storage3dLocation()
@@ -353,10 +352,10 @@ namespace AndreasReitberger.NUnitTest
                 Assert.That(newItem?.Amount == startAmount + 0.75);
 
                 // Just to check if the unit conversion is working
-                location.TakeFromStock(material, 0.001, Unit.MetricTons, false);
+                location.TakeFromStock(material, 0.0005, Unit.MetricTons, false);
                 newItem = location.Items.FirstOrDefault(curItem => curItem.Material == material);
                 // Check if the addition was successfully
-                Assert.That(newItem?.Amount == startAmount + 0.75 - 1);
+                Assert.That(newItem?.Amount == startAmount + 0.75 - 0.5);
             }
             catch (Exception exc)
             {

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
@@ -838,7 +838,7 @@ namespace AndreasReitberger.NUnitTest
                 if (!realm.IsClosed)
                 {
                     realm.Write(() => realm.RemoveAll());
-                    double startAmount = 2.68;
+                    double startAmount = 0;
                     Material3d material = new()
                     {
                         Name = "Test",
@@ -853,7 +853,6 @@ namespace AndreasReitberger.NUnitTest
                     Storage3dItem item = new()
                     {
                         Material = material,
-                        Amount = startAmount,
                     };
                     realm.Write(() => realm.Add(item));
                     Storage3d storage = new()
@@ -870,10 +869,10 @@ namespace AndreasReitberger.NUnitTest
                         Assert.That(newItem?.Amount == startAmount + 0.75);
 
                         // Just to check if the unit conversion is working
-                        storage.TakeFromStock(material, 0.001, Unit.MetricTons, false);
+                        storage.TakeFromStock(material, 0.0005, Unit.MetricTons, false);
                         newItem = storage.Items.FirstOrDefault(curItem => curItem.Material.Id == material.Id);
                         // Check if the addition was successfully
-                        Assert.That(newItem?.Amount == startAmount + 0.75 - 1);
+                        Assert.That(newItem?.Amount == startAmount + 0.75 - 0.5);
                     });
                 }
             }

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Sqlite.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Sqlite.cs
@@ -1148,7 +1148,7 @@ namespace AndreasReitberger.NUnitTest
                     await DatabaseHandler.Instance.RebuildAllTableAsync();
                     await Task.Delay(250);
 
-                    double startAmount = 2.68;
+                    double startAmount = 0;
                     Material3d material = new()
                     {
                         Name = "Test",
@@ -1162,7 +1162,6 @@ namespace AndreasReitberger.NUnitTest
                     Storage3dItem item = new()
                     {
                         Material = material,
-                        Amount = startAmount,
                     };
 
                     Storage3dLocation location = new()
@@ -1195,17 +1194,14 @@ namespace AndreasReitberger.NUnitTest
                     transactions.Add(transaction1);
 
                     // Just to check if the unit conversion is working
-                    Storage3dTransaction transaction2 = location.TakeFromStock(material, 0.001, Unit.MetricTons, null, false);
+                    Storage3dTransaction transaction2 = location.TakeFromStock(material, 0.0005, Unit.MetricTons, null, false);
                     newItem = location.Items.FirstOrDefault(curItem => curItem.Material == material);
                     // Check if the addition was successfully
-                    Assert.That(newItem?.Amount == startAmount + 0.75 - 1);
+                    Assert.That(newItem?.Amount == startAmount + 0.75 - 0.5);
                     transactions.Add(transaction2);
                     await DatabaseHandler.Instance.SetStorageTransactionsWithChildrenAsync(transactions);
 
                     List<Storage3dTransaction>? transactionsLoaded = await DatabaseHandler.Instance.GetStorageTransactionsWithChildrenAsync();
-                    Assert.That(transactionsLoaded?.Count == transactions?.Count);
-
-                    transactionsLoaded = await DatabaseHandler.Instance.GetStorageTransactionsWithChildrenAsync(newItem);
                     Assert.That(transactionsLoaded?.Count == transactions?.Count);
                 }
             }

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
@@ -741,7 +741,7 @@ namespace AndreasReitberger.NUnitTest
         {
             try
             {
-                double startAmount = 2.68;
+                double startAmount = 0;
                 Print3d.Models.Material3d material = new()
                 {
                     Name = "Test",
@@ -754,7 +754,6 @@ namespace AndreasReitberger.NUnitTest
                 Print3d.Models.StorageAdditions.Storage3dItem item = new()
                 {
                     Material = material,
-                    Amount = startAmount,
                 };
 
                 Print3d.Models.StorageAdditions.Storage3dLocation location = new()
@@ -775,10 +774,10 @@ namespace AndreasReitberger.NUnitTest
                 Assert.That(newItem?.Amount == startAmount + 0.75);
 
                 // Just to check if the unit conversion is working
-                location.TakeFromStock(material, 0.001, Unit.MetricTons, false);
+                location.TakeFromStock(material, 0.0005, Unit.MetricTons, false);
                 newItem = location.Items.FirstOrDefault(curItem => curItem.Material == material);
                 // Check if the addition was successfully
-                Assert.That(newItem?.Amount == startAmount + 0.75 - 1);
+                Assert.That(newItem?.Amount == startAmount + 0.75 - 0.5);
             }
             catch (Exception exc)
             {

--- a/source/3dPrintCalculatorLibrary.Realm/Models/Storage3d.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/Storage3d.cs
@@ -39,64 +39,70 @@ namespace AndreasReitberger.Print3d.Realm
 
         public void AddToStock(Storage3dItem item, double amount, Unit unit)
         {
-            if (item?.Material != null)
+            if (item?.Material is not null)
             {
+                Storage3dTransaction transaction = new()
+                {
+                    DateTime = DateTimeOffset.Now,
+                    Unit = unit,
+                };
                 if (item?.Material.Unit == unit)
                 {
-                    item.Amount += amount;
+                    transaction.Amount += amount;
                 }
                 else
                 {
                     int target = UnitFactor.GetUnitFactor(item.Material.Unit);
                     int current = UnitFactor.GetUnitFactor(unit);
 
-                    item.Amount += target > current ? amount / (target / current) : amount * (current / target);
+                    transaction.Amount += target > current ? amount / (target / current) : amount * (current / target);
                 }
+                item.Transactions.Add(transaction);
             }
         }
-        public void AddToStock(Material3d material, double amount, Unit unit)
+        public Storage3dTransaction? AddToStock(Material3d material, double amount, Unit unit)
         {
-            Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            Storage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (item?.Material != null)
                 AddToStock(item: item, amount: amount, unit: unit);
             else
                 CreateStockItem(material, amount, unit);
+            return item?.Transactions.LastOrDefault();
         }
 
-        public Storage3dTransaction AddToStock(Material3d material, double amount, Unit unit, Guid? calculationId = null)
+        public Storage3dTransaction? AddToStock(Material3d material, double amount, Unit unit, Guid? calculationId = null)
         {
-            Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            Storage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (item?.Material != null)
                 AddToStock(item: item, amount: amount, unit: unit);
             else
                 item = CreateStockItem(material, amount, unit);
-            return new()
-            {
-                Amount = amount,
-                Unit = unit,
-                CalculationId = calculationId,
-                DateTime = DateTime.Now,
-                Item = item,
-            };
+            return item?.Transactions.LastOrDefault();
         }
 
         public bool TakeFromStock(Storage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
             if (item?.Material != null)
             {
-                if (item.Amount >= amount)
+                Storage3dTransaction transaction = new()
                 {
-                    if (item?.Material.Unit == unit)
-                    {
-                        item.Amount -= amount;
-                    }
-                    else
-                    {
-                        int target = UnitFactor.GetUnitFactor(item.Material.Unit);
-                        int current = UnitFactor.GetUnitFactor(unit);
+                    DateTime = DateTimeOffset.Now,
+                    Unit = unit,
+                };
+                if (item?.Material.Unit == unit)
+                {
+                    transaction.Amount -= amount;
+                }
+                else
+                {
+                    int target = UnitFactor.GetUnitFactor(item.Material.Unit);
+                    int current = UnitFactor.GetUnitFactor(unit);
 
-                        item.Amount -= target > current ? amount / (target / current) : amount * (current / target);
-                    }
+                    transaction.Amount -= target > current ? amount / (target / current) : amount * (current / target);
+                }
+                if (item?.Amount + transaction.Amount >= 0)
+                {
+                    item?.Transactions.Add(transaction);
                     return true;
                 }
                 else if (throwIfMaterialIsNotInStock)
@@ -114,23 +120,16 @@ namespace AndreasReitberger.Print3d.Realm
 
         public bool TakeFromStock(Material3d material, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
-            Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            Storage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             return TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock);
         }
 
-        public Storage3dTransaction TakeFromStock(Material3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
+        public Storage3dTransaction? TakeFromStock(Material3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
         {
-            Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            Storage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock))
             {
-                return new()
-                {
-                    Amount = -amount,
-                    Unit = unit,
-                    CalculationId = calculationId,
-                    DateTime = DateTime.Now,
-                    Item = item,
-                };
+                return item?.Transactions.LastOrDefault();
             }
             else return null;
         }

--- a/source/3dPrintCalculatorLibrary.Realm/Models/StorageAdditions/Storage3dItem.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/StorageAdditions/Storage3dItem.cs
@@ -1,6 +1,8 @@
 ﻿using AndreasReitberger.Print3d.Interfaces;
 using Realms;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace AndreasReitberger.Print3d.Realm.StorageAdditions
 {
@@ -16,7 +18,9 @@ namespace AndreasReitberger.Print3d.Realm.StorageAdditions
 
         public Material3d Material { get; set; }
 
-        public double Amount { get; set; }
+        public IList<Storage3dTransaction> Transactions { get; }
+
+        public double Amount => GetAvailableAmount();
         #endregion
 
         #region Ctor
@@ -24,6 +28,11 @@ namespace AndreasReitberger.Print3d.Realm.StorageAdditions
         {
             Id = Guid.NewGuid();
         }
+        #endregion
+
+        #region Methods
+        public double GetAvailableAmount() => Transactions?.Select(x => x.Amount).Sum() ?? 0;
+
         #endregion
     }
 }

--- a/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.Library.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.Library.cs
@@ -788,7 +788,7 @@ namespace AndreasReitberger.Print3d.SQLite
 
         #region Storage Transaction
         public Task<List<Storage3dTransaction>> GetStorageTransactionsWithChildrenAsync() => DatabaseAsync.GetAllWithChildrenAsync<Storage3dTransaction>(recursive: true);
-        public Task<List<Storage3dTransaction>> GetStorageTransactionsWithChildrenAsync(Storage3dItem item) => DatabaseAsync.GetAllWithChildrenAsync<Storage3dTransaction>(filter: transaction => transaction.StorageItemId == item.Id, recursive: true);
+        //public Task<List<Storage3dTransaction>> GetStorageTransactionsWithChildrenAsync(Storage3dItem item) => DatabaseAsync.GetAllWithChildrenAsync<Storage3dTransaction>(filter: transaction => transaction.StorageItemId == item.Id, recursive: true);
 
         public Task<Storage3dTransaction> GetStorageTransactionWithChildrenAsync(Guid id) => DatabaseAsync.GetWithChildrenAsync<Storage3dTransaction>(id, recursive: true);
 

--- a/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/DatabaseHandler.cs
@@ -115,6 +115,7 @@ namespace AndreasReitberger.Print3d.SQLite
             typeof(Storage3d),
             typeof(Storage3dLocationStorage3d),
             typeof(Storage3dItemStorage3dLocation),
+            typeof(Storage3dItemStorage3dTransaction),
             typeof(ProcedureAddition),
             typeof(ProcedureCalculationParameter),
             typeof(Print3dInfo),

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Storage3d.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Storage3d.cs
@@ -1,5 +1,7 @@
-﻿using AndreasReitberger.Print3d.Interfaces;
+﻿using AndreasReitberger.Print3d.Enums;
+using AndreasReitberger.Print3d.Interfaces;
 using AndreasReitberger.Print3d.SQLite.StorageAdditions;
+using AndreasReitberger.Print3d.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
 using SQLite;
 using SQLiteNetExtensions.Attributes;
@@ -23,7 +25,7 @@ namespace AndreasReitberger.Print3d.SQLite
 
         [ObservableProperty]
         [property: ManyToMany(typeof(Storage3dLocationStorage3d), CascadeOperations = CascadeOperation.All)]
-        ObservableCollection<Storage3dLocation> locations = new();
+        ObservableCollection<Storage3dLocation> locations = [];
         #endregion
 
         #region Ctor
@@ -35,75 +37,79 @@ namespace AndreasReitberger.Print3d.SQLite
 
         #region Methods
 
-        /*
-        public Storage3dItem CreateStockItem(Material3d material, double amount = 0, Unit unit = Unit.Kilogram)
+        public Storage3dItem CreateStockItem(Storage3dLocation location, Material3d material, double amount = 0, Unit unit = Unit.Kilogram)
         {
             Storage3dItem item = new() { Material = material };
-            if (amount != 0) UpdateStockAmount(item, amount, unit);
-            Items?.Add(item);
+            if (amount != 0) UpdateStockAmount(location: location, item, amount, unit);
+            location?.Items?.Add(item);
             return item;
         }
 
-        public void AddToStock(Storage3dItem item, double amount, Unit unit)
+        public void AddToStock(Storage3dLocation location, Storage3dItem item, double amount, Unit unit)
         {
-            if (item?.Material != null)
+            if (item?.Material is not null)
             {
+                Storage3dTransaction transaction = new()
+                {
+                    DateTime = DateTimeOffset.Now,
+                    Unit = unit,
+                };
                 if (item?.Material.Unit == unit)
                 {
-                    item.Amount += amount;
+                    transaction.Amount += amount;
                 }
                 else
                 {
                     int target = UnitFactor.GetUnitFactor(item.Material.Unit);
                     int current = UnitFactor.GetUnitFactor(unit);
 
-                    item.Amount += target > current ? amount / (target / current) : amount * (current / target);
+                    transaction.Amount += target > current ? amount / (target / current) : amount * (current / target);
                 }
+                item.Transactions?.Add(transaction);
             }
         }
-        public void AddToStock(Material3d material, double amount, Unit unit)
+        public void AddToStock(Storage3dLocation location, Material3d material, double amount, Unit unit)
         {
-            Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            Storage3dItem? item = location?.Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (item?.Material != null)
-                AddToStock(item: item, amount: amount, unit: unit);
+                AddToStock(location: location, item: item, amount: amount, unit: unit);
             else
-                CreateStockItem(material, amount, unit);
+                CreateStockItem(location: location, material, amount, unit);
         }
 
-        public Storage3dTransaction AddToStock(Material3d material, double amount, Unit unit, Guid? calculationId = null)
+        public Storage3dTransaction? AddToStock(Storage3dLocation location, Material3d material, double amount, Unit unit, Guid? calculationId = null)
         {
-            Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            Storage3dItem? item = location?.Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (item?.Material != null)
-                AddToStock(item: item, amount: amount, unit: unit);
+                AddToStock(location: location, item: item, amount: amount, unit: unit);
             else
-                item = CreateStockItem(material, amount, unit);
-            return new()
-            {
-                Amount = amount,
-                Unit = unit,
-                CalculationId = calculationId,
-                DateTime = DateTime.Now,
-                Item = item,
-            };
+                item = CreateStockItem(location: location, material, amount, unit);
+            return item?.Transactions.LastOrDefault();
         }
 
-        public bool TakeFromStock(Storage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
+        public bool TakeFromStock(Storage3dLocation location, Storage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
-            if (item?.Material != null)
+            if (item?.Material is not null)
             {
-                if (item.Amount >= amount)
+                Storage3dTransaction transaction = new()
                 {
-                    if (item?.Material.Unit == unit)
-                    {
-                        item.Amount -= amount;
-                    }
-                    else
-                    {
-                        int target = UnitFactor.GetUnitFactor(item.Material.Unit);
-                        int current = UnitFactor.GetUnitFactor(unit);
+                    DateTime = DateTimeOffset.Now,
+                    Unit = unit,
+                };
+                if (item?.Material.Unit == unit)
+                {
+                    transaction.Amount -= amount;
+                }
+                else
+                {
+                    int target = UnitFactor.GetUnitFactor(item.Material.Unit);
+                    int current = UnitFactor.GetUnitFactor(unit);
 
-                        item.Amount -= target > current ? amount / (target / current) : amount * (current / target);
-                    }
+                    transaction.Amount -= target > current ? amount / (target / current) : amount * (current / target);
+                }
+                if (item?.Amount + transaction.Amount >= 0)
+                {
+                    item?.Transactions.Add(transaction);
                     return true;
                 }
                 else if (throwIfMaterialIsNotInStock)
@@ -119,43 +125,36 @@ namespace AndreasReitberger.Print3d.SQLite
             else return false;
         }
 
-        public bool TakeFromStock(Material3d material, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
+        public bool TakeFromStock(Storage3dLocation location, Material3d material, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
-            Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
-            return TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock);
+            Storage3dItem? item = location?.Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            return TakeFromStock(location: location, item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock);
         }
 
-        public Storage3dTransaction TakeFromStock(Material3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
+        public Storage3dTransaction? TakeFromStock(Storage3dLocation location, Material3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
         {
-            Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
-            if (TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock))
+            Storage3dItem? item = location?.Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            if (TakeFromStock(location: location, item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock))
             {
-                return new()
-                {
-                    Amount = -amount,
-                    Unit = unit,
-                    CalculationId = calculationId,
-                    DateTime = DateTime.Now,
-                    Item = item,
-                };
+                return item?.Transactions.LastOrDefault();
             }
             else return null;
         }
 
-        public bool UpdateStockAmount(Storage3dItem item, double amount, Unit unit = Unit.Kilogram)
+        public bool UpdateStockAmount(Storage3dLocation location, Storage3dItem item, double amount, Unit unit = Unit.Kilogram)
         {
             if (amount > 0)
             {
-                AddToStock(item: item, amount: amount, unit: unit);
+                AddToStock(location: location, item: item, amount: amount, unit: unit);
                 return true;
             }
             else if (amount < 0)
             {
-                return TakeFromStock(item: item, amount: Math.Abs(amount), unit: unit);
+                return TakeFromStock(location: location, item: item, amount: Math.Abs(amount), unit: unit);
             }
             return false;
         }
-        */
+
         #endregion
     }
 }

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dItem.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dItem.cs
@@ -2,6 +2,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using SQLite;
 using SQLiteNetExtensions.Attributes;
+using System.Collections.ObjectModel;
 
 namespace AndreasReitberger.Print3d.SQLite.StorageAdditions
 {
@@ -12,10 +13,6 @@ namespace AndreasReitberger.Print3d.SQLite.StorageAdditions
         [ObservableProperty]
         [property: PrimaryKey]
         Guid id;
-
-        //[ObservableProperty]
-        //[property: ForeignKey(typeof(Storage3dLocation))]
-        //Guid storageLocationId;
 
         [ObservableProperty]
         string name;
@@ -28,7 +25,11 @@ namespace AndreasReitberger.Print3d.SQLite.StorageAdditions
         Material3d material;
 
         [ObservableProperty]
-        double amount;
+        [NotifyPropertyChangedFor(nameof(Amount))]
+        [property: ManyToMany(typeof(Storage3dItemStorage3dTransaction), CascadeOperations = CascadeOperation.All)]
+        ObservableCollection<Storage3dTransaction> transactions = [];
+
+        public double Amount => GetAvailableAmount();
         #endregion
 
         #region Ctor
@@ -36,6 +37,11 @@ namespace AndreasReitberger.Print3d.SQLite.StorageAdditions
         {
             Id = Guid.NewGuid();
         }
+        #endregion
+
+        #region Methods
+        public double GetAvailableAmount() => Transactions?.Select(x => x.Amount).Sum() ?? 0;
+
         #endregion
     }
 }

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dItemStorage3dTransaction.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dItemStorage3dTransaction.cs
@@ -1,0 +1,16 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using SQLiteNetExtensions.Attributes;
+
+namespace AndreasReitberger.Print3d.SQLite.StorageAdditions
+{
+    public partial class Storage3dItemStorage3dTransaction : ObservableObject
+    {
+        [ObservableProperty]
+        [property: ForeignKey(typeof(Storage3dTransaction))]
+        Guid storageTransactionId;
+
+        [ObservableProperty]
+        [property: ForeignKey(typeof(Storage3dItem))]
+        Guid storageItemId;
+    }
+}

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dLocation.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dLocation.cs
@@ -48,70 +48,68 @@ namespace AndreasReitberger.Print3d.SQLite.StorageAdditions
         {
             if (item?.Material is not null)
             {
+                Storage3dTransaction transaction = new()
+                {
+                    DateTime = DateTimeOffset.Now,
+                    Unit = unit,
+                };
                 if (item?.Material.Unit == unit)
                 {
-                    item.Amount += amount;
+                    transaction.Amount += amount;
                 }
                 else
                 {
                     int target = UnitFactor.GetUnitFactor(item.Material.Unit);
                     int current = UnitFactor.GetUnitFactor(unit);
 
-                    item.Amount += target > current ? amount / (target / current) : amount * (current / target);
+                    transaction.Amount += target > current ? amount / (target / current) : amount * (current / target);
                 }
+                item.Transactions.Add(transaction);
             }
         }
-        public Storage3dTransaction AddToStock(Material3d material, double amount, Unit unit)
+        public Storage3dTransaction? AddToStock(Material3d material, double amount, Unit unit)
         {
             Storage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (item?.Material != null)
                 AddToStock(item: item, amount: amount, unit: unit);
             else
                 item = CreateStockItem(material, amount, unit);
-            return new()
-            {
-                Amount = amount,
-                Unit = unit,
-                CalculationId = null,
-                DateTime = DateTime.Now,
-                Item = item,
-            };
+            return item.Transactions.LastOrDefault();
         }
 
-        public Storage3dTransaction AddToStock(Material3d material, double amount, Unit unit, Guid? calculationId = null)
+        public Storage3dTransaction? AddToStock(Material3d material, double amount, Unit unit, Guid? calculationId = null)
         {
             Storage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (item?.Material != null)
                 AddToStock(item: item, amount: amount, unit: unit);
             else
                 item = CreateStockItem(material, amount, unit);
-            return new()
-            {
-                Amount = amount,
-                Unit = unit,
-                CalculationId = calculationId,
-                DateTime = DateTime.Now,
-                Item = item,
-            };
+            return item.Transactions.LastOrDefault();
         }
 
         public bool TakeFromStock(Storage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
             if (item?.Material is not null)
             {
-                if (item.Amount >= amount)
+                Storage3dTransaction transaction = new()
                 {
-                    if (item?.Material.Unit == unit)
-                    {
-                        item.Amount -= amount;
-                    }
-                    else
-                    {
-                        int target = UnitFactor.GetUnitFactor(item.Material.Unit);
-                        int current = UnitFactor.GetUnitFactor(unit);
+                    DateTime = DateTimeOffset.Now,
+                    Unit = unit,
+                }; 
+                if (item?.Material.Unit == unit)
+                {
+                    transaction.Amount -= amount;
+                }
+                else
+                {
+                    int target = UnitFactor.GetUnitFactor(item.Material.Unit);
+                    int current = UnitFactor.GetUnitFactor(unit);
 
-                        item.Amount -= target > current ? amount / (target / current) : amount * (current / target);
-                    }
+                    transaction.Amount -= target > current ? amount / (target / current) : amount * (current / target);
+                }
+                if (item?.Amount + transaction.Amount >= 0)
+                {
+                    item?.Transactions.Add(transaction);
                     return true;
                 }
                 else if (throwIfMaterialIsNotInStock)
@@ -133,19 +131,12 @@ namespace AndreasReitberger.Print3d.SQLite.StorageAdditions
             return TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock);
         }
 
-        public Storage3dTransaction TakeFromStock(Material3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
+        public Storage3dTransaction? TakeFromStock(Material3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
         {
             Storage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock))
             {
-                return new()
-                {
-                    Amount = -amount,
-                    Unit = unit,
-                    CalculationId = calculationId,
-                    DateTime = DateTime.Now,
-                    Item = item,
-                };
+                return item.Transactions.LastOrDefault(); ;
             }
             else return null;
         }

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dTransaction.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dTransaction.cs
@@ -23,19 +23,21 @@ namespace AndreasReitberger.Print3d.SQLite.StorageAdditions
 
         [ObservableProperty]
         DateTimeOffset dateTime;
-
+        /*
         [ObservableProperty]
         Guid storageItemId;
 
         [ObservableProperty]
         [property: ManyToOne(nameof(StorageItemId), CascadeOperations = CascadeOperation.All)]
         Storage3dItem item;
+        */
+
+        [ObservableProperty]
+        Unit unit;
 
         [ObservableProperty]
         double amount;
 
-        [ObservableProperty]
-        Unit unit;
         #endregion
 
         #region Ctor

--- a/source/3dPrintCalculatorLibrary/Interfaces/IStorage3dItem.cs
+++ b/source/3dPrintCalculatorLibrary/Interfaces/IStorage3dItem.cs
@@ -7,7 +7,11 @@ namespace AndreasReitberger.Print3d.Interfaces
         #region Properties
         public Guid Id { get; set; }
         public string Name { get; set; }
-        public double Amount { get; set; }
+        public double Amount { get; }
+        #endregion
+
+        #region Methods
+        public double GetAvailableAmount();
         #endregion
     }
 }

--- a/source/3dPrintCalculatorLibrary/Models/StorageAdditions/Storage3dItem.cs
+++ b/source/3dPrintCalculatorLibrary/Models/StorageAdditions/Storage3dItem.cs
@@ -1,6 +1,8 @@
 ﻿using AndreasReitberger.Print3d.Interfaces;
 using CommunityToolkit.Mvvm.ComponentModel;
 using System;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace AndreasReitberger.Print3d.Models.StorageAdditions
 {
@@ -20,7 +22,10 @@ namespace AndreasReitberger.Print3d.Models.StorageAdditions
         Material3d material;
 
         [ObservableProperty]
-        double amount;
+        [NotifyPropertyChangedFor(nameof(Amount))]
+        ObservableCollection<Storage3dTransaction> transactions = [];
+
+        public double Amount => GetAvailableAmount();
         #endregion
 
         #region Ctor
@@ -28,6 +33,11 @@ namespace AndreasReitberger.Print3d.Models.StorageAdditions
         {
             Id = Guid.NewGuid();
         }
+        #endregion
+
+        #region Methods
+        public double GetAvailableAmount() => Transactions?.Select(x => x.Amount).Sum() ?? 0;
+
         #endregion
     }
 }

--- a/source/3dPrintCalculatorLibrary/Models/StorageAdditions/Storage3dLocation.cs
+++ b/source/3dPrintCalculatorLibrary/Models/StorageAdditions/Storage3dLocation.cs
@@ -43,64 +43,70 @@ namespace AndreasReitberger.Print3d.Models.StorageAdditions
 
         public void AddToStock(Storage3dItem item, double amount, Unit unit)
         {
-            if (item?.Material != null)
+            if (item?.Material is not null)
             {
+                Storage3dTransaction transaction = new()
+                {
+                    DateTime = DateTimeOffset.Now,
+                    Unit = unit,
+                };
                 if (item?.Material.Unit == unit)
                 {
-                    item.Amount += amount;
+                    transaction.Amount += amount;
                 }
                 else
                 {
                     int target = UnitFactor.GetUnitFactor(item.Material.Unit);
                     int current = UnitFactor.GetUnitFactor(unit);
 
-                    item.Amount += target > current ? amount / (target / current) : amount * (current / target);
+                    transaction.Amount += target > current ? amount / (target / current) : amount * (current / target);
                 }
+                item.Transactions.Add(transaction);
             }
         }
-        public void AddToStock(Material3d material, double amount, Unit unit)
+        public Storage3dTransaction? AddToStock(Material3d material, double amount, Unit unit)
         {
-            Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            Storage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (item?.Material != null)
                 AddToStock(item: item, amount: amount, unit: unit);
             else
                 CreateStockItem(material, amount, unit);
+            return item?.Transactions.LastOrDefault();
         }
 
-        public Storage3dTransaction AddToStock(Material3d material, double amount, Unit unit, Guid? calculationId = null)
+        public Storage3dTransaction? AddToStock(Material3d material, double amount, Unit unit, Guid? calculationId = null)
         {
-            Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            Storage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (item?.Material != null)
                 AddToStock(item: item, amount: amount, unit: unit);
             else
                 item = CreateStockItem(material, amount, unit);
-            return new()
-            {
-                Amount = amount,
-                Unit = unit,
-                CalculationId = calculationId,
-                DateTime = DateTime.Now,
-                Item = item,
-            };
+            return item?.Transactions.LastOrDefault();
         }
 
         public bool TakeFromStock(Storage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
-            if (item?.Material != null)
+            if (item?.Material is not null)
             {
-                if (item.Amount >= amount)
+                Storage3dTransaction transaction = new()
                 {
-                    if (item?.Material.Unit == unit)
-                    {
-                        item.Amount -= amount;
-                    }
-                    else
-                    {
-                        int target = UnitFactor.GetUnitFactor(item.Material.Unit);
-                        int current = UnitFactor.GetUnitFactor(unit);
+                    DateTime = DateTimeOffset.Now,
+                    Unit = unit,
+                };
+                if (item?.Material.Unit == unit)
+                {
+                    transaction.Amount -= amount;
+                }
+                else
+                {
+                    int target = UnitFactor.GetUnitFactor(item.Material.Unit);
+                    int current = UnitFactor.GetUnitFactor(unit);
 
-                        item.Amount -= target > current ? amount / (target / current) : amount * (current / target);
-                    }
+                    transaction.Amount -= target > current ? amount / (target / current) : amount * (current / target);
+                }
+                if (item?.Amount + transaction.Amount >= 0)
+                {
+                    item?.Transactions.Add(transaction);
                     return true;
                 }
                 else if (throwIfMaterialIsNotInStock)
@@ -122,19 +128,12 @@ namespace AndreasReitberger.Print3d.Models.StorageAdditions
             return TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock);
         }
 
-        public Storage3dTransaction TakeFromStock(Material3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
+        public Storage3dTransaction? TakeFromStock(Material3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
         {
             Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             if (TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock))
             {
-                return new()
-                {
-                    Amount = -amount,
-                    Unit = unit,
-                    CalculationId = calculationId,
-                    DateTime = DateTime.Now,
-                    Item = item,
-                };
+                return item?.Transactions.LastOrDefault();
             }
             else return null;
         }


### PR DESCRIPTION
This PR updates the `Storage3dItem` to hold its `Storage3dTransactions`. Also the `Amount` property is now read only and will be calculated out of the transactions.

Fixed #103