### PR TITLE
Generalized all return types for `Storage3d` methods

### DIFF
--- a/source/3dPrintCalculatorLibrary.Core/Interfaces/IStorage3dLocation.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Interfaces/IStorage3dLocation.cs
@@ -16,13 +16,13 @@ namespace AndreasReitberger.Print3d.Core.Interfaces
         #region Methods
 
         public IStorage3dItem CreateStockItem(IMaterial3d material, double amount = 0, Unit unit = Unit.Kilogram);
-        public void AddToStock(IStorage3dItem item, double amount, Unit unit);
+        public IStorage3dTransaction AddToStock(IStorage3dItem item, double amount, Unit unit);
         public IStorage3dTransaction AddToStock(IMaterial3d material, double amount, Unit unit);
         public IStorage3dTransaction AddToStock(IMaterial3d material, double amount, Unit unit, Guid? calculationId = null);
-        public bool TakeFromStock(IStorage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false);
-        public bool TakeFromStock(IMaterial3d material, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false);
+        public IStorage3dTransaction TakeFromStock(IStorage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false);
+        public IStorage3dTransaction TakeFromStock(IMaterial3d material, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false);
         public IStorage3dTransaction TakeFromStock(IMaterial3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false);
-        public bool UpdateStockAmount(IStorage3dItem item, double amount, Unit unit = Unit.Kilogram);
+        public IStorage3dTransaction UpdateStockAmount(IStorage3dItem item, double amount, Unit unit = Unit.Kilogram);
         #endregion
     }
 }

--- a/source/3dPrintCalculatorLibrary.Core/Interfaces/IStorage3dTransaction.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Interfaces/IStorage3dTransaction.cs
@@ -10,6 +10,7 @@ namespace AndreasReitberger.Print3d.Core.Interfaces
         public IStorage3dItem Item { get; set; }
         public double Amount { get; set; }
         public Unit Unit { get; set; }
+        public bool IsAddition { get; }
         #endregion
     }
 }

--- a/source/3dPrintCalculatorLibrary.Core/Models/Storage3dTransaction.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Models/Storage3dTransaction.cs
@@ -19,9 +19,16 @@ namespace AndreasReitberger.Print3d.Core
 
         [ObservableProperty]
         double amount;
+        partial void OnAmountChanged(double value)
+        {
+            IsAddition = value > 0;
+        }
 
         [ObservableProperty]
         Unit unit;
+
+        [ObservableProperty]
+        bool isAddition = false;
         #endregion
 
         #region Ctor

--- a/source/3dPrintCalculatorLibrary.Realm/Models/StorageAdditions/Storage3dLocation.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/StorageAdditions/Storage3dLocation.cs
@@ -39,7 +39,7 @@ namespace AndreasReitberger.Print3d.Realm.StorageAdditions
             return item;
         }
 
-        public void AddToStock(Storage3dItem item, double amount, Unit unit)
+        public Storage3dTransaction? AddToStock(Storage3dItem item, double amount, Unit unit)
         {
             if (item?.Material != null)
             {
@@ -60,7 +60,9 @@ namespace AndreasReitberger.Print3d.Realm.StorageAdditions
                     transaction.Amount += target > current ? amount / (target / current) : amount * (current / target);
                 }
                 item.Transactions.Add(transaction);
+                return transaction;
             }
+            else return null;
         }
         public Storage3dTransaction? AddToStock(Material3d material, double amount, Unit unit)
         {
@@ -82,7 +84,7 @@ namespace AndreasReitberger.Print3d.Realm.StorageAdditions
             return item?.Transactions.LastOrDefault();
         }
 
-        public bool TakeFromStock(Storage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
+        public Storage3dTransaction? TakeFromStock(Storage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
             if (item?.Material != null)
             {
@@ -105,49 +107,44 @@ namespace AndreasReitberger.Print3d.Realm.StorageAdditions
                 if (item?.Amount + transaction.Amount >= 0)
                 {
                     item?.Transactions.Add(transaction);
-                    return true;
+                    return transaction;
                 }
                 else if (throwIfMaterialIsNotInStock)
                 {
                     throw new ArgumentOutOfRangeException($"The amount of the material `{item?.Material}` is not sufficient for this transaction (In stock: {item?.Amount} / Requested: {amount}!");
                 }
-                else return false;
+                else return null;
             }
             else if (throwIfMaterialIsNotInStock)
             {
                 throw new ArgumentOutOfRangeException($"The material `{item?.Material}` is not available in the stock!");
             }
-            else return false;
+            else return null;
         }
 
-        public bool TakeFromStock(Material3d material, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
+        public Storage3dTransaction? TakeFromStock(Material3d material, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
-            Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            Storage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             return TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock);
         }
 
         public Storage3dTransaction? TakeFromStock(Material3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
         {
             Storage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
-            if (TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock))
-            {
-                return item?.Transactions.LastOrDefault();
-            }
-            else return null;
+            return TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock);
         }
 
-        public bool UpdateStockAmount(Storage3dItem item, double amount, Unit unit = Unit.Kilogram)
+        public Storage3dTransaction? UpdateStockAmount(Storage3dItem item, double amount, Unit unit = Unit.Kilogram)
         {
             if (amount > 0)
             {
-                AddToStock(item: item, amount: amount, unit: unit);
-                return true;
+                return AddToStock(item: item, amount: amount, unit: unit);
             }
             else if (amount < 0)
             {
                 return TakeFromStock(item: item, amount: Math.Abs(amount), unit: unit);
             }
-            return false;
+            return null;
         }
         #endregion
     }

--- a/source/3dPrintCalculatorLibrary.Realm/Models/StorageAdditions/Storage3dTransaction.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/StorageAdditions/Storage3dTransaction.cs
@@ -25,6 +25,8 @@ namespace AndreasReitberger.Print3d.Realm.StorageAdditions
             set { UnitId = (int)value; }
         }
         public int UnitId { get; set; }
+
+        public bool IsAddition { get; }
         #endregion
 
         #region Ctor

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dTransaction.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/StorageAdditions/Storage3dTransaction.cs
@@ -23,21 +23,19 @@ namespace AndreasReitberger.Print3d.SQLite.StorageAdditions
 
         [ObservableProperty]
         DateTimeOffset dateTime;
-        /*
-        [ObservableProperty]
-        Guid storageItemId;
-
-        [ObservableProperty]
-        [property: ManyToOne(nameof(StorageItemId), CascadeOperations = CascadeOperation.All)]
-        Storage3dItem item;
-        */
 
         [ObservableProperty]
         Unit unit;
 
         [ObservableProperty]
         double amount;
+        partial void OnAmountChanged(double value)
+        {
+            IsAddition = value > 0;
+        }
 
+        [ObservableProperty]
+        bool isAddition = false;
         #endregion
 
         #region Ctor

--- a/source/3dPrintCalculatorLibrary/Interfaces/IStorage3dTransaction.cs
+++ b/source/3dPrintCalculatorLibrary/Interfaces/IStorage3dTransaction.cs
@@ -15,6 +15,8 @@ namespace AndreasReitberger.Print3d.Interfaces
         public double Amount { get; set; }
 
         public Unit Unit { get; set; }
+        public bool IsAddition { get; }
+
         #endregion
     }
 }

--- a/source/3dPrintCalculatorLibrary/Models/StorageAdditions/Storage3dLocation.cs
+++ b/source/3dPrintCalculatorLibrary/Models/StorageAdditions/Storage3dLocation.cs
@@ -41,7 +41,7 @@ namespace AndreasReitberger.Print3d.Models.StorageAdditions
             return item;
         }
 
-        public void AddToStock(Storage3dItem item, double amount, Unit unit)
+        public Storage3dTransaction? AddToStock(Storage3dItem item, double amount, Unit unit)
         {
             if (item?.Material is not null)
             {
@@ -62,7 +62,9 @@ namespace AndreasReitberger.Print3d.Models.StorageAdditions
                     transaction.Amount += target > current ? amount / (target / current) : amount * (current / target);
                 }
                 item.Transactions.Add(transaction);
+                return transaction;
             }
+            else return null;
         }
         public Storage3dTransaction? AddToStock(Material3d material, double amount, Unit unit)
         {
@@ -84,7 +86,7 @@ namespace AndreasReitberger.Print3d.Models.StorageAdditions
             return item?.Transactions.LastOrDefault();
         }
 
-        public bool TakeFromStock(Storage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
+        public Storage3dTransaction? TakeFromStock(Storage3dItem item, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
             if (item?.Material is not null)
             {
@@ -107,49 +109,44 @@ namespace AndreasReitberger.Print3d.Models.StorageAdditions
                 if (item?.Amount + transaction.Amount >= 0)
                 {
                     item?.Transactions.Add(transaction);
-                    return true;
+                    return transaction;
                 }
                 else if (throwIfMaterialIsNotInStock)
                 {
                     throw new ArgumentOutOfRangeException($"The amount of the material `{item?.Material}` is not sufficient for this transaction (In stock: {item?.Amount} / Requested: {amount}!");
                 }
-                else return false;
+                else return null;
             }
             else if (throwIfMaterialIsNotInStock)
             {
                 throw new ArgumentOutOfRangeException($"The material `{item?.Material}` is not available in the stock!");
             }
-            else return false;
+            else return null;
         }
 
-        public bool TakeFromStock(Material3d material, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
+        public Storage3dTransaction? TakeFromStock(Material3d material, double amount, Unit unit, bool throwIfMaterialIsNotInStock = false)
         {
-            Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            Storage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
             return TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock);
         }
 
         public Storage3dTransaction? TakeFromStock(Material3d material, double amount, Unit unit, Guid? calculationId = null, bool throwIfMaterialIsNotInStock = false)
         {
-            Storage3dItem item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
-            if (TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock))
-            {
-                return item?.Transactions.LastOrDefault();
-            }
-            else return null;
+            Storage3dItem? item = Items?.FirstOrDefault(curItem => curItem?.Material?.Id == material?.Id);
+            return TakeFromStock(item: item, amount: amount, unit: unit, throwIfMaterialIsNotInStock: throwIfMaterialIsNotInStock);
         }
 
-        public bool UpdateStockAmount(Storage3dItem item, double amount, Unit unit = Unit.Kilogram)
+        public Storage3dTransaction? UpdateStockAmount(Storage3dItem item, double amount, Unit unit = Unit.Kilogram)
         {
             if (amount > 0)
             {
-                AddToStock(item: item, amount: amount, unit: unit);
-                return true;
+                return AddToStock(item: item, amount: amount, unit: unit);
             }
             else if (amount < 0)
             {
                 return TakeFromStock(item: item, amount: Math.Abs(amount), unit: unit);
             }
-            return false;
+            return null;
         }
         #endregion
     }

--- a/source/3dPrintCalculatorLibrary/Models/StorageAdditions/Storage3dTransaction.cs
+++ b/source/3dPrintCalculatorLibrary/Models/StorageAdditions/Storage3dTransaction.cs
@@ -22,9 +22,16 @@ namespace AndreasReitberger.Print3d.Models.StorageAdditions
 
         [ObservableProperty]
         double amount;
+        partial void OnAmountChanged(double value)
+        {
+            IsAddition = value > 0;
+        }
 
         [ObservableProperty]
         Unit unit;
+
+        [ObservableProperty]
+        bool isAddition = false;
         #endregion
 
         #region Ctor


### PR DESCRIPTION
This PR sets the same return type for all helper methods available in Storage3d` and Storage3dItem`.

Fixed #105