### PR TITLE
Fixed `CalculateCost` to use `Material3dUsage.PercentageValue`

### DIFF
--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3dEnhanced.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3dEnhanced.Extensions.cs
@@ -64,7 +64,7 @@ namespace AndreasReitberger.Print3d.SQLite
                             FileName = file.FileName,
                         });
                     }
-                    double percentageUsage = info.MaterialUsages?.Select(mu => mu.Percentage).Sum() ?? 1;
+                    double percentageUsage = info.MaterialUsages?.Select(mu => mu.PercentageValue).Sum() ?? 1;
                     if (percentageUsage > 1 || percentageUsage <= 0)
                         throw new ArgumentOutOfRangeException($"The overall percentage of the material usage is greater than 1 (=100%): {percentageUsage}");
                     foreach (Material3dUsage materialUsageInfo in info.MaterialUsages)
@@ -84,7 +84,7 @@ namespace AndreasReitberger.Print3d.SQLite
                                 _weight = file.Weight.Weight * Convert.ToDouble(UnitFactor.GetUnitFactor(file.Weight.Unit));
                             }
                             // Needed material in g
-                            double _material = _weight * file.Quantity * materialUsageInfo.Percentage;
+                            double _material = _weight * file.Quantity * materialUsageInfo.PercentageValue;
                             MaterialUsage?.Add(new CalculationAttribute()
                             {
                                 Attribute = material.Name,


### PR DESCRIPTION
This PR fixes that the `Percentage` still was used for the `CalculateCost` methods.

Fixed #111