### PR TITLE
Fixed `ProcedureAddition` calculation

### DIFF
--- a/source/3dPrintCalculatorLibrary.Core/Interfaces/ICalculationProcedureAttribute.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Interfaces/ICalculationProcedureAttribute.cs
@@ -11,6 +11,8 @@ namespace AndreasReitberger.Print3d.Core.Interfaces
         public ProcedureAttribute Attribute { get; set; }
         public IList<ICalculationProcedureParameter> Parameters { get; set; }
         public CalculationLevel Level { get; set; }
+        public bool PerPiece { get; set; }
+        public bool PerFile { get; set; }
         #endregion
     }
 }

--- a/source/3dPrintCalculatorLibrary.Core/Models/Calculation3dEnhanced.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Models/Calculation3dEnhanced.Extensions.cs
@@ -1,6 +1,7 @@
 ﻿using AndreasReitberger.Print3d.Core.Enums;
 using AndreasReitberger.Print3d.Core.Interfaces;
 using AndreasReitberger.Print3d.Core.Utilities;
+using System.Diagnostics;
 
 namespace AndreasReitberger.Print3d.Core
 {
@@ -249,15 +250,19 @@ namespace AndreasReitberger.Print3d.Core
                             {
                                 foreach (ICalculationProcedureParameter parameter in attribute.Parameters)
                                 {
-                                    OverallPrinterCosts?.Add(new CalculationAttribute()
+                                    if (attribute.PerFile || (OverallPrinterCosts?
+                                            .FirstOrDefault(attr => attr.Attribute == parameter.Type.ToString() && attr.LinkedId == printer.Id) is null))
                                     {
-                                        LinkedId = printer.Id,
-                                        Attribute = parameter.Type.ToString(),
-                                        Type = CalculationAttributeType.ProcedureSpecificAddition,
-                                        Value = parameter.Value * file.Quantity,
-                                        FileId = file.Id,
-                                        FileName = file.FileName,
-                                    });
+                                        OverallPrinterCosts?.Add(new CalculationAttribute()
+                                        {
+                                            LinkedId = printer.Id,
+                                            Attribute = parameter.Type.ToString(),
+                                            Type = CalculationAttributeType.ProcedureSpecificAddition,
+                                            Value = attribute.PerPiece ? parameter.Value * file.Quantity : parameter.Value,
+                                            FileId = file.Id,
+                                            FileName = file.FileName,
+                                        });
+                                    }
                                 }
                             }
 

--- a/source/3dPrintCalculatorLibrary.Core/Models/Calculation3dEnhanced.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Models/Calculation3dEnhanced.Extensions.cs
@@ -62,7 +62,7 @@ namespace AndreasReitberger.Print3d.Core
                             FileName = file.FileName,
                         });
                     }
-                    double percentageUsage = info.Materials?.Select(mu => mu.Percentage).Sum() ?? 1;
+                    double percentageUsage = info.Materials?.Select(mu => mu.PercentageValue).Sum() ?? 1;
                     if (percentageUsage > 1 || percentageUsage <= 0)
                         throw new ArgumentOutOfRangeException($"The overall percentage of the material usage is greater than 1 (=100%): {percentageUsage}");
                     foreach (IMaterial3dUsage materialUsageInfo in info.Materials)
@@ -81,7 +81,7 @@ namespace AndreasReitberger.Print3d.Core
                                 _weight = file.Weight.Weight * Convert.ToDouble(UnitFactor.GetUnitFactor(file.Weight.Unit));
                             }
                             // Needed material in g
-                            double _material = _weight * file.Quantity * materialUsageInfo.Percentage;
+                            double _material = _weight * file.Quantity * materialUsageInfo.PercentageValue;
                             MaterialUsages?.Add(new CalculationAttribute()
                             {
                                 Attribute = material.Name,

--- a/source/3dPrintCalculatorLibrary.Core/Models/CalculationProcedureAttribute.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Models/CalculationProcedureAttribute.cs
@@ -24,6 +24,15 @@ namespace AndreasReitberger.Print3d.Core
 
         [ObservableProperty]
         CalculationLevel level = CalculationLevel.Printer;
+
+        /// <summary>
+        /// Multiplies the costs per piece (quantity of the files)
+        /// </summary>
+        [ObservableProperty]
+        bool perPiece = false;
+
+        [ObservableProperty]
+        bool perFile = false;
         #endregion
 
         #region Constructor

--- a/source/3dPrintCalculatorLibrary.NUnitTest/3dPrintCalculatorLibrary.NUnitTest.csproj
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/3dPrintCalculatorLibrary.NUnitTest.csproj
@@ -19,7 +19,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="coverlet.collector" Version="6.0.0">
+	  <PackageReference Include="coverlet.collector" Version="6.0.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Core.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Core.cs
@@ -19,6 +19,23 @@ namespace AndreasReitberger.NUnitTest
         [SetUp]
         public void Setup()
         {
+            IPrinter3d printerFDM = new Printer3d()
+            {
+                Type = Printer3dType.FDM,
+                Model = "i3 MK3S",
+                PowerConsumption = 210,
+                Price = 899,
+                MaterialType = Material3dFamily.Filament,
+            };
+            IPrinter3d printerDLP = new Printer3d()
+            {
+                Type = Printer3dType.DLP,
+                Model = "Photon X",
+                PowerConsumption = 160,
+                Price = 599,
+                MaterialType = Material3dFamily.Resin,
+            };
+
             calculation = new Calculation3dEnhanced()
             {
                 Name = "Test",
@@ -96,14 +113,7 @@ namespace AndreasReitberger.NUnitTest
                                 PercentageValue = 0.5,
                             }
                         ],
-                        Printer = new Printer3d()
-                        {
-                            Type = Printer3dType.FDM,
-                            Model = "i3 MK3S",
-                            PowerConsumption = 210,
-                            Price = 899,
-                            MaterialType = Material3dFamily.Filament,
-                        },
+                        Printer = printerFDM,
                         Items = [
                             new Item3dUsage()
                             {
@@ -149,14 +159,40 @@ namespace AndreasReitberger.NUnitTest
                                 PercentageValue = 1,
                             }
                         ],
-                        Printer = new Printer3d()
+                        Printer = printerDLP,
+                    },
+                    new Print3dInfo()
+                    {
+                        Name = "My first resin print job",
+                        File = new File3d()
                         {
-                            Type = Printer3dType.DLP,
-                            Model = "Photon X",
-                            PowerConsumption = 160,
-                            Price = 599,
-                            MaterialType = Material3dFamily.Resin,
-                        }
+                            FileName = "Superman.dlp",
+                            PrintTime = 1.42,
+                            Volume = 35.4536,
+                            Quantity = 3,
+                        },
+                        Materials = [
+                            new Material3dUsage()
+                            {
+                                Material = new Material3d()
+                                {
+                                    Name = "Anycubic Tough Resin",
+                                    Density = 1.11,
+                                    ColorCode = "#000000",
+                                    MaterialFamily = Material3dFamily.Resin,
+                                    TypeOfMaterial = new Material3dType() { Family = Material3dFamily.Resin, Material = "TOUGH" },
+                                    PackageSize = 1,
+                                    Unit = Unit.Liters,
+                                    UnitPrice = 65,
+                                    Manufacturer = new Manufacturer()
+                                    {
+                                        Name = "Anycubic",
+                                    }
+                                },
+                                PercentageValue = 1,
+                            }
+                        ],
+                        Printer = printerDLP,
                     }
                 ],
                 WorkstepUsages = [
@@ -238,14 +274,6 @@ namespace AndreasReitberger.NUnitTest
                 FailRate = 5,
                 State = CalculationState.Draft,
                 ApplyProcedureSpecificAdditions = true,
-                ProcedureAdditions =
-                [
-                    new ProcedureAddition() 
-                    {
-                        Target = ProcedureAdditionTarget.Machine,
-
-                    },
-                ]
             };
 
             List<ICalculationProcedureParameter> parameters = [];
@@ -268,7 +296,7 @@ namespace AndreasReitberger.NUnitTest
                         new CalculationProcedureParameter()
                         {
                             Type = ProcedureParameter.GloveCosts,
-                            Value = 2 * (25 / 100),
+                            Value = 2d * (25d / 100d),
                             Additions = additionalInfo,
                         }
                     ];
@@ -279,6 +307,8 @@ namespace AndreasReitberger.NUnitTest
                             Family = Material3dFamily.Resin,
                             Parameters = parameters,
                             Level = CalculationLevel.Printer,
+                            PerFile = false,
+                            PerPiece = false,
                         });
                 }
             }
@@ -291,7 +321,7 @@ namespace AndreasReitberger.NUnitTest
                     [
                         new CalculationProcedureParameterAddition("amount", 5),
                         new CalculationProcedureParameterAddition("price", 50),
-                        new CalculationProcedureParameterAddition("perjob", 0.01d),
+                        new CalculationProcedureParameterAddition("perjob", 0.1d),
                     ];
 
                     parameters =
@@ -299,7 +329,7 @@ namespace AndreasReitberger.NUnitTest
                         new CalculationProcedureParameter()
                         {
                             Type = ProcedureParameter.WashingCosts,
-                            Value = 0.01d * (5 / 50),
+                            Value = 0.1d * (50d / 5d),
                             Additions = additionalInfo,
                         }
                     ];
@@ -310,6 +340,8 @@ namespace AndreasReitberger.NUnitTest
                             Family = Material3dFamily.Resin,
                             Parameters = parameters,
                             Level = CalculationLevel.Printer,
+                            PerPiece = true,
+                            PerFile = true,
                         });
                 }
             }
@@ -330,7 +362,7 @@ namespace AndreasReitberger.NUnitTest
                         new CalculationProcedureParameter()
                         {
                             Type = ProcedureParameter.FilterCosts,
-                            Value = 1 * (25 / 50),
+                            Value = 1d * (25d / 50d),
                             Additions = additionalInfo,
                         }
                     ];
@@ -341,6 +373,8 @@ namespace AndreasReitberger.NUnitTest
                             Family = Material3dFamily.Resin,
                             Parameters = parameters,
                             Level = CalculationLevel.Printer,
+                            PerFile = true,
+                            PerPiece = false,
                         });
                 }
             }
@@ -359,8 +393,9 @@ namespace AndreasReitberger.NUnitTest
                         new CalculationProcedureParameter()
                         {
                             Type = ProcedureParameter.ResinTankWearCosts,
-                            Value = 120  * 0.01d,
+                            Value = 120d  * 0.01d,
                             Additions = additionalInfo,
+                            
                         }
                     ];
                     calculation.ProcedureAttributes.Add(
@@ -370,11 +405,11 @@ namespace AndreasReitberger.NUnitTest
                             Family = Material3dFamily.Resin,
                             Parameters = parameters,
                             Level = CalculationLevel.Printer,
-
+                            PerPiece = false,
+                            PerFile = true,
                         });
                 }
             }
-
         }
 
         [Test]
@@ -382,18 +417,48 @@ namespace AndreasReitberger.NUnitTest
         {
             try
             {
+                Assert.That(calculation is not null);
+                Assert.That(calculation?.ProcedureAttributes?.Count > 0);
                 calculation.ApplyProcedureSpecificAdditions = false;
                 calculation.CalculateCosts();
                 var total = calculation.TotalCosts;
 
                 calculation.ApplyProcedureSpecificAdditions = true;
+                calculation.CalculateCosts();
                 var total2 = calculation.TotalCosts;
                 Assert.That(total < total2);
-                var procedureCosts = calculation.Costs;
+
+                /*
+                 * GloveCosts: Should be available only once per machine and print job
+                 * FilterCosts: Should be available once per print job info
+                 * WashingCosts: Are per print job info and file quantity
+                 */
+
+                var gloveCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "GloveCosts")?.ToList();
+                Assert.That(gloveCosts?.Count == calculation.AvailablePrinters.Where(printer => printer.MaterialType == Material3dFamily.Resin).Count());
+                Assert.That(gloveCosts?.Sum(c => c.Value) == 0.5d);
+
+                int fileCount = calculation.PrintInfos.Where(pi => pi.Printer.MaterialType == Material3dFamily.Resin).Count();
+
+                var filterCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "FilterCosts")?.ToList();
+                Assert.That(filterCosts?.Count == fileCount);
+                Assert.That(filterCosts?.Sum(c => c.Value) == 1d);
+
+                var washingCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "WashingCosts")?.ToList();
+                Assert.That(washingCosts?.Count == fileCount);
+                foreach(var washCost in washingCosts)
+                {
+                    IFile3d f = calculation.PrintInfos.FirstOrDefault(pi => pi.File.Id == washCost.FileId).File;
+                    Assert.That(washCost.Value / f.Quantity  == 1d);
+                }
+
+                var tankWearCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "ResinTankWearCosts")?.ToList();
+                Assert.That(tankWearCosts?.Count == fileCount);
+                Assert.That(tankWearCosts?.Sum(c => c.Value) == 2.4d);
             }
             catch (Exception ex)
             {
-
+                Assert.Fail(ex.Message);
             }
         }
 

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Core.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Core.cs
@@ -8,6 +8,12 @@ namespace AndreasReitberger.NUnitTest
 {
     public class TestsCore
     {
+        bool ApplyResinGlovesCosts =  true;
+        bool ApplyResinWashingCosts =  true;
+        bool ApplyResinFilterCosts =  true;
+        bool ApplyResinTankWearCosts =  true;
+
+
         ICalculation3dEnhanced? calculation;
 
         [SetUp]
@@ -68,7 +74,7 @@ namespace AndreasReitberger.NUnitTest
                                         Name = "Prusa",
                                     }
                                 },
-                                Percentage = 0.5,
+                                PercentageValue = 0.5,
                             },
                             new Material3dUsage()
                             {
@@ -87,7 +93,7 @@ namespace AndreasReitberger.NUnitTest
                                         Name = "Prusa",
                                     }
                                 },
-                                Percentage = 0.5,
+                                PercentageValue = 0.5,
                             }
                         ],
                         Printer = new Printer3d()
@@ -120,7 +126,7 @@ namespace AndreasReitberger.NUnitTest
                             FileName = "Batman.dlp",
                             PrintTime = 2.65,
                             Volume = 65.546,
-                            Quantity = 2,
+                            Quantity = 20,
                         },
                         Materials = [
                             new Material3dUsage()
@@ -140,7 +146,7 @@ namespace AndreasReitberger.NUnitTest
                                         Name = "Anycubic",
                                     }
                                 },
-                                Percentage = 1,
+                                PercentageValue = 1,
                             }
                         ],
                         Printer = new Printer3d()
@@ -231,10 +237,165 @@ namespace AndreasReitberger.NUnitTest
                     ],
                 FailRate = 5,
                 State = CalculationState.Draft,
+                ApplyProcedureSpecificAdditions = true,
+                ProcedureAdditions =
+                [
+                    new ProcedureAddition() 
+                    {
+                        Target = ProcedureAdditionTarget.Machine,
+
+                    },
+                ]
             };
+
+            List<ICalculationProcedureParameter> parameters = [];
+            List<ICalculationProcedureParameterAddition> additionalInfo = [];
+
+            if (ApplyResinGlovesCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                        new CalculationProcedureParameterAddition("amount", 100),
+                        new CalculationProcedureParameterAddition("price", 25),
+                        new CalculationProcedureParameterAddition("perjob", 2),
+                    ];
+
+                    parameters =
+                    [
+                        new CalculationProcedureParameter()
+                        {
+                            Type = ProcedureParameter.GloveCosts,
+                            Value = 2 * (25 / 100),
+                            Additions = additionalInfo,
+                        }
+                    ];
+                    calculation.ProcedureAttributes.Add(
+                        new CalculationProcedureAttribute()
+                        {
+                            Attribute = ProcedureAttribute.GlovesCosts,
+                            Family = Material3dFamily.Resin,
+                            Parameters = parameters,
+                            Level = CalculationLevel.Printer,
+                        });
+                }
+            }
+            if (ApplyResinWashingCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                        new CalculationProcedureParameterAddition("amount", 5),
+                        new CalculationProcedureParameterAddition("price", 50),
+                        new CalculationProcedureParameterAddition("perjob", 0.01d),
+                    ];
+
+                    parameters =
+                    [
+                        new CalculationProcedureParameter()
+                        {
+                            Type = ProcedureParameter.WashingCosts,
+                            Value = 0.01d * (5 / 50),
+                            Additions = additionalInfo,
+                        }
+                    ];
+                    calculation.ProcedureAttributes.Add(
+                        new CalculationProcedureAttribute()
+                        {
+                            Attribute = ProcedureAttribute.WashingCosts,
+                            Family = Material3dFamily.Resin,
+                            Parameters = parameters,
+                            Level = CalculationLevel.Printer,
+                        });
+                }
+            }
+            if (ApplyResinFilterCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                        new CalculationProcedureParameterAddition("amount", 50),
+                        new CalculationProcedureParameterAddition("price", 25),
+                        new CalculationProcedureParameterAddition("perjob", 1),
+                    ];
+
+                    parameters =
+                    [
+                        new CalculationProcedureParameter()
+                        {
+                            Type = ProcedureParameter.FilterCosts,
+                            Value = 1 * (25 / 50),
+                            Additions = additionalInfo,
+                        }
+                    ];
+                    calculation.ProcedureAttributes.Add(
+                        new CalculationProcedureAttribute()
+                        {
+                            Attribute = ProcedureAttribute.FilterCosts,
+                            Family = Material3dFamily.Resin,
+                            Parameters = parameters,
+                            Level = CalculationLevel.Printer,
+                        });
+                }
+            }
+            if (ApplyResinTankWearCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo = 
+                    [
+                            new CalculationProcedureParameterAddition("replacementcosts", 120),
+                            new CalculationProcedureParameterAddition("wearfactor", 0.01d)
+                    ];
+                    parameters =
+                    [
+                        new CalculationProcedureParameter()
+                        {
+                            Type = ProcedureParameter.ResinTankWearCosts,
+                            Value = 120  * 0.01d,
+                            Additions = additionalInfo,
+                        }
+                    ];
+                    calculation.ProcedureAttributes.Add(
+                        new CalculationProcedureAttribute()
+                        {
+                            Attribute = ProcedureAttribute.ResinTankWear,
+                            Family = Material3dFamily.Resin,
+                            Parameters = parameters,
+                            Level = CalculationLevel.Printer,
+
+                        });
+                }
+            }
+
         }
 
+        [Test]
+        public void TestProcedureSpecificAddition()
+        {
+            try
+            {
+                calculation.ApplyProcedureSpecificAdditions = false;
+                calculation.CalculateCosts();
+                var total = calculation.TotalCosts;
 
+                calculation.ApplyProcedureSpecificAdditions = true;
+                var total2 = calculation.TotalCosts;
+                Assert.That(total < total2);
+                var procedureCosts = calculation.Costs;
+            }
+            catch (Exception ex)
+            {
+
+            }
+        }
 
         [Test]
         public void Item3dTests()
@@ -544,7 +705,7 @@ namespace AndreasReitberger.NUnitTest
                     IPrint3dInfo info = new Print3dInfo()
                     {
                         File = file,
-                        Materials = [new Material3dUsage() { Material = material, Percentage = 1 }],
+                        Materials = [new Material3dUsage() { Material = material, PercentageValue = 1 }],
                         Printer = printer,
                         Items = [usage],
                     };
@@ -552,7 +713,7 @@ namespace AndreasReitberger.NUnitTest
                     {
                         File = file2,
                         // Multi-Material for one file
-                        Materials = [new Material3dUsage() { Material = material, Percentage = 0.5 }, new Material3dUsage() { Material = material2, Percentage = 0.5 }],
+                        Materials = [new Material3dUsage() { Material = material, PercentageValue = 0.5 }, new Material3dUsage() { Material = material2, PercentageValue = 0.5 }],
                         Printer = printer2,
                     };
 

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
@@ -1214,7 +1214,7 @@ namespace AndreasReitberger.NUnitTest
                         File = file,
                         Printer = printer,
                     };
-                    info.MaterialUsages.Add(new() { Material = material, Percentage = 1 });
+                    info.MaterialUsages.Add(new() { Material = material, PercentageValue = 1 });
                     info.Items.Add(usage);
 
                     Print3dInfo info2 = new()
@@ -1222,8 +1222,8 @@ namespace AndreasReitberger.NUnitTest
                         File = file2,
                         Printer = printer2,
                     };
-                    info2.MaterialUsages.Add(new() { Material = material, Percentage = 0.5 });
-                    info2.MaterialUsages.Add(new() { Material = material2, Percentage = 0.5 });
+                    info2.MaterialUsages.Add(new() { Material = material, PercentageValue = 0.5 });
+                    info2.MaterialUsages.Add(new() { Material = material2, PercentageValue = 0.5 });
 
                     Calculation3dEnhanced calc = new()
                     {

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
@@ -5,6 +5,7 @@ using AndreasReitberger.Print3d.Realm.MaterialAdditions;
 using AndreasReitberger.Print3d.Realm.StorageAdditions;
 using AndreasReitberger.Print3d.Realm.WorkstepAdditions;
 using AndreasReitberger.Print3d.Realm.ProcedureAdditions;
+using AndreasReitberger.Print3d.Realm.CustomerAdditions;
 using NUnit.Framework;
 using Realms;
 
@@ -12,9 +13,463 @@ namespace AndreasReitberger.NUnitTest
 {
     public class TestsRealm
     {
+        bool ApplyResinGlovesCosts = true;
+        bool ApplyResinWashingCosts = true;
+        bool ApplyResinFilterCosts = true;
+        bool ApplyResinTankWearCosts = true;
+
+        Calculation3dEnhanced? calculation;
+
         [SetUp]
         public void Setup()
         {
+            Printer3d printerFDM = new Printer3d()
+            {
+                Type = Printer3dType.FDM,
+                Model = "i3 MK3S",
+                PowerConsumption = 210,
+                Price = 899,
+                MaterialType = Material3dFamily.Filament,
+            };
+            Printer3d printerDLP = new Printer3d()
+            {
+                Type = Printer3dType.DLP,
+                Model = "Photon X",
+                PowerConsumption = 160,
+                Price = 599,
+                MaterialType = Material3dFamily.Resin,
+            };
+
+            Customer3d costumer = new()
+            {
+                Name = "Max",
+                LastName = "Mustermann",
+                IsCompany = false,
+            };
+            costumer.EmailAddresses.Add(new Email()
+            {
+                EmailAddress = "max.mustermann@example.com"
+            });
+            costumer.Addresses.Add(new Address()
+            {
+                City = "Muserstadt",
+                Zip = "93426",
+                CountryCode = "de",
+                Street = "Musterstraße 4",
+            });
+
+            // FDM job
+            var pi1 = new Print3dInfo()
+            {
+                Name = "My awesome print job",
+                File = new File3d()
+                {
+                    FileName = "my.gcode",
+                    PrintTime = 5.263,
+                    Volume = 35.54,
+                    Quantity = 5,
+                },
+                Printer = printerFDM,
+            };
+            pi1.MaterialUsages.Add(new Material3dUsage()
+            {
+                Material = new Material3d()
+                {
+                    Name = "Prusament PETG 1kg JetBlack",
+                    Density = 1.24,
+                    ColorCode = "#000000",
+                    MaterialFamily = Material3dFamily.Filament,
+                    TypeOfMaterial = new Material3dType() { Family = Material3dFamily.Filament, Material = "PETG" },
+                    PackageSize = 1,
+                    Unit = Unit.Kilogram,
+                    UnitPrice = 30,
+                    Manufacturer = new Manufacturer()
+                    {
+                        Name = "Prusa",
+                    }
+                },
+                PercentageValue = 0.5,
+            });
+            pi1.MaterialUsages.Add(new Material3dUsage()
+            {
+                Material = new Material3d()
+                {
+                    Name = "Prusament PLA 1kg JetBlack",
+                    Density = 1.24,
+                    ColorCode = "#000000",
+                    MaterialFamily = Material3dFamily.Filament,
+                    TypeOfMaterial = new Material3dType() { Family = Material3dFamily.Filament, Material = "PLA" },
+                    PackageSize = 1,
+                    Unit = Unit.Kilogram,
+                    UnitPrice = 25,
+                    Manufacturer = new Manufacturer()
+                    {
+                        Name = "Prusa",
+                    }
+                },
+                PercentageValue = 0.5,
+            });
+            pi1.Items.Add(new Item3dUsage()
+            {
+                Item = new Item3d()
+                {
+                    Name = "M3x16 Screws",
+                    PackagePrice = 20,
+                    PackageSize = 100,
+                },
+                Quantity = 10,
+            });
+            
+            // Resing job
+            var pi2 = new Print3dInfo()
+            {
+                Name = "My first resin print job",
+                File = new File3d()
+                {
+                    FileName = "Batman.dlp",
+                    PrintTime = 2.65,
+                    Volume = 65.546,
+                    Quantity = 20,
+                },
+                Printer = printerDLP,
+            };
+            pi2.MaterialUsages.Add(new Material3dUsage()
+            {
+                Material = new Material3d()
+                {
+                    Name = "Anycubic Tough Resin",
+                    Density = 1.11,
+                    ColorCode = "#000000",
+                    MaterialFamily = Material3dFamily.Resin,
+                    TypeOfMaterial = new Material3dType() { Family = Material3dFamily.Resin, Material = "TOUGH" },
+                    PackageSize = 1,
+                    Unit = Unit.Liters,
+                    UnitPrice = 65,
+                    Manufacturer = new Manufacturer()
+                    {
+                        Name = "Anycubic",
+                    }
+                },
+                PercentageValue = 1,
+            });
+            
+            var pi3 = new Print3dInfo()
+            {
+                Name = "My first resin print job",
+                File = new File3d()
+                {
+                    FileName = "Superman.dlp",
+                    PrintTime = 1.42,
+                    Volume = 35.4536,
+                    Quantity = 3,
+                },
+                Printer = printerDLP,
+            };
+            pi3.MaterialUsages.Add(new Material3dUsage()
+            {
+                Material = new Material3d()
+                {
+                    Name = "Anycubic Tough Resin",
+                    Density = 1.11,
+                    ColorCode = "#000000",
+                    MaterialFamily = Material3dFamily.Resin,
+                    TypeOfMaterial = new Material3dType() { Family = Material3dFamily.Resin, Material = "TOUGH" },
+                    PackageSize = 1,
+                    Unit = Unit.Liters,
+                    UnitPrice = 65,
+                    Manufacturer = new Manufacturer()
+                    {
+                        Name = "Anycubic",
+                    }
+                },
+                PercentageValue = 1,
+            });
+
+            calculation = new Calculation3dEnhanced()
+            {
+                Name = "Test",
+                Customer = costumer,
+                ApplyEnergyCost = true,
+                PowerLevel = 75,
+                EnergyCostsPerkWh = 0.4,
+                FailRate = 5,
+                State = CalculationState.Draft,
+                ApplyProcedureSpecificAdditions = true,
+            };
+            calculation.PrintInfos.Add(pi1);
+            calculation.PrintInfos.Add(pi2);
+            calculation.PrintInfos.Add(pi3);
+
+            calculation.WorkstepUsages.Add(new WorkstepUsage()
+            {
+                Workstep = new Workstep()
+                {
+                    Name = "Cleanup",
+                    CalculationType = CalculationType.PerPiece,
+                    Category = new WorkstepCategory() { Name = "Post-Processing" },
+                    Price = 0.5,
+                    Note = "Contains the removal of supports and general cleanup",
+                    Type = WorkstepType.Post,
+                },
+                UsageParameter = new WorkstepUsageParameter()
+                {
+                    ParameterType = WorkstepUsageParameterType.Quantity,
+                    Value = 1,
+                }
+            });
+            calculation.WorkstepUsages.Add(new WorkstepUsage()
+            {
+                Workstep = new Workstep()
+                {
+                    Name = "Packaging",
+                    CalculationType = CalculationType.PerJob,
+                    Category = new WorkstepCategory() { Name = "Post-Processing" },
+                    Price = 1,
+                    Note = "Contains the packaging of the prints",
+                    Type = WorkstepType.Post,
+                },
+                UsageParameter = new WorkstepUsageParameter()
+                {
+                    ParameterType = WorkstepUsageParameterType.Quantity,
+                    Value = 1,
+                }
+            });
+
+            calculation.AdditionalItems.Add(new Item3dUsage()
+            {
+                Item = new Item3d()
+                {
+
+                    Name = "Nuts M3",
+                    PackageSize = 100,
+                    PackagePrice = 9.99d,
+                    Manufacturer = new Manufacturer()
+                    {
+                        Name = "Würth",
+                        DebitorNumber = "DE26265126",
+                        Website = "https://www.wuerth.de/",
+                    },
+                    SKU = "2302423-1223"
+                },
+                Quantity = 2,
+            });
+            calculation.AdditionalItems.Add(new Item3dUsage()
+            {
+                Item = new Item3d()
+                {
+                    Name = "Screws M3 20mm",
+                    PackageSize = 50,
+                    PackagePrice = 14.99d,
+                    Manufacturer = new Manufacturer()
+                    {
+                        Name = "Würth",
+                        DebitorNumber = "DE26265126",
+                        Website = "https://www.wuerth.de/",
+                    },
+                    SKU = "2302423-6413"
+                },
+                Quantity = 2,
+            });
+
+            List<CalculationProcedureParameter> parameters = [];
+            List<CalculationProcedureParameterAddition> additionalInfo = [];
+
+            if (ApplyResinGlovesCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                        new CalculationProcedureParameterAddition("amount", 100),
+                        new CalculationProcedureParameterAddition("price", 25),
+                        new CalculationProcedureParameterAddition("perjob", 2),
+                    ];
+                    var ad1 = new CalculationProcedureParameter()
+                    {
+                        Type = ProcedureParameter.GloveCosts,
+                        Value = 2d * (25d / 100d),
+                    };
+                    foreach (var add in additionalInfo)
+                        ad1.Additions.Add(add);
+                    parameters =
+                    [
+                        ad1
+                    ];
+                    var cpa1 = new CalculationProcedureAttribute()
+                    {
+                        Attribute = ProcedureAttribute.GlovesCosts,
+                        Family = Material3dFamily.Resin,
+                        Level = CalculationLevel.Printer,
+                        PerFile = false,
+                        PerPiece = false,
+                    };
+                    foreach(var para in parameters)
+                        parameters.Add(para);
+                    calculation.ProcedureAttributes.Add(cpa1);
+                }
+            }
+            if (ApplyResinWashingCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                        new CalculationProcedureParameterAddition("amount", 5),
+                        new CalculationProcedureParameterAddition("price", 50),
+                        new CalculationProcedureParameterAddition("perjob", 0.1d),
+                    ];
+
+                    var ad2 = new CalculationProcedureParameter()
+                    {
+                        Type = ProcedureParameter.WashingCosts,
+                        Value = 0.1d * (50d / 5d),
+                    };
+                    foreach (var add in additionalInfo)
+                        ad2.Additions.Add(add);
+                    parameters =
+                    [
+                        ad2
+                    ];
+
+                    var cpa2 = new CalculationProcedureAttribute()
+                    {
+                        Attribute = ProcedureAttribute.WashingCosts,
+                        Family = Material3dFamily.Resin,
+                        Level = CalculationLevel.Printer,
+                        PerPiece = true,
+                        PerFile = true,
+                    };
+
+                    foreach (var para in parameters)
+                        parameters.Add(para);
+                    calculation.ProcedureAttributes.Add(cpa2);
+                }
+            }
+            if (ApplyResinFilterCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                        new CalculationProcedureParameterAddition("amount", 50),
+                        new CalculationProcedureParameterAddition("price", 25),
+                        new CalculationProcedureParameterAddition("perjob", 1),
+                    ];
+
+                    var ad3 = new CalculationProcedureParameter()
+                    {
+                        Type = ProcedureParameter.FilterCosts,
+                        Value = 1d * (25d / 50d),
+                    };
+                    foreach (var add in additionalInfo)
+                        ad3.Additions.Add(add);
+                    parameters =
+                    [
+                        ad3
+                    ];
+
+                    var cpa3 = new CalculationProcedureAttribute()
+                    {
+                        Attribute = ProcedureAttribute.FilterCosts,
+                        Family = Material3dFamily.Resin,
+                        Level = CalculationLevel.Printer,
+                        PerFile = true,
+                        PerPiece = false,
+                    };
+                    foreach (var para in parameters)
+                        parameters.Add(para);
+                    calculation.ProcedureAttributes.Add(cpa3);
+                }
+            }
+            if (ApplyResinTankWearCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                            new CalculationProcedureParameterAddition("replacementcosts", 120),
+                            new CalculationProcedureParameterAddition("wearfactor", 0.01d)
+                    ];
+
+                    var ad4 = new CalculationProcedureParameter()
+                    {
+                        Type = ProcedureParameter.ResinTankWearCosts,
+                        Value = 120d * 0.01d,
+                    };
+                    foreach (var add in additionalInfo)
+                        ad4.Additions.Add(add);
+                    parameters =
+                    [
+                        ad4
+                    ];
+                    var cpa4 = new CalculationProcedureAttribute()
+                    {
+                        Attribute = ProcedureAttribute.ResinTankWear,
+                        Family = Material3dFamily.Resin,
+                        Level = CalculationLevel.Printer,
+                        PerPiece = false,
+                        PerFile = true,
+                    };
+
+                    foreach (var para in parameters)
+                        parameters.Add(para);
+                    calculation.ProcedureAttributes.Add(cpa4);
+                }
+            }
+        }
+
+        [Test]
+        public void TestProcedureSpecificAddition()
+        {
+            try
+            {
+                Assert.That(calculation is not null);
+                Assert.That(calculation?.ProcedureAttributes?.Count > 0);
+                calculation.ApplyProcedureSpecificAdditions = false;
+                calculation.CalculateCosts();
+                var total = calculation.TotalCosts;
+
+                calculation.ApplyProcedureSpecificAdditions = true;
+                calculation.CalculateCosts();
+                var total2 = calculation.TotalCosts;
+                Assert.That(total < total2);
+
+                /*
+                 * GloveCosts: Should be available only once per machine and print job
+                 * FilterCosts: Should be available once per print job info
+                 * WashingCosts: Are per print job info and file quantity
+                 */
+
+                var gloveCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "GloveCosts")?.ToList();
+                Assert.That(gloveCosts?.Count == calculation.AvailablePrinters.Where(printer => printer.MaterialType == Material3dFamily.Resin).Count());
+                Assert.That(gloveCosts?.Sum(c => c.Value) == 0.5d);
+
+                int fileCount = calculation.PrintInfos.Where(pi => pi.Printer.MaterialType == Material3dFamily.Resin).Count();
+
+                var filterCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "FilterCosts")?.ToList();
+                Assert.That(filterCosts?.Count == fileCount);
+                Assert.That(filterCosts?.Sum(c => c.Value) == 1d);
+
+                var washingCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "WashingCosts")?.ToList();
+                Assert.That(washingCosts?.Count == fileCount);
+                foreach (var washCost in washingCosts)
+                {
+                    File3d f = calculation.PrintInfos.FirstOrDefault(pi => pi.File.Id == washCost.FileId).File;
+                    Assert.That(washCost.Value / f.Quantity == 1d);
+                }
+
+                var tankWearCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "ResinTankWearCosts")?.ToList();
+                Assert.That(tankWearCosts?.Count == fileCount);
+                Assert.That(tankWearCosts?.Sum(c => c.Value) == 2.4d);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message);
+            }
         }
 
         [Test]
@@ -258,7 +713,7 @@ namespace AndreasReitberger.NUnitTest
             }
         }
 
-        private Calculation3d _calculation;
+        private Calculation3d calculationObsolete;
         [Test]
         public void TestCalculation()
         {
@@ -332,20 +787,20 @@ namespace AndreasReitberger.NUnitTest
                     LinkedToFile = false,
                 };
 
-                _calculation = new();
+                calculationObsolete = new();
                 // Add data
-                _calculation.AdditionalItems.Add(usage);
-                _calculation.Files.Add(file);
-                _calculation.Files.Add(file2);
-                _calculation.Printers.Add(printer);
-                _calculation.Materials.Add(material);
-                _calculation.Rates.Add(new()
+                calculationObsolete.AdditionalItems.Add(usage);
+                calculationObsolete.Files.Add(file);
+                calculationObsolete.Files.Add(file2);
+                calculationObsolete.Printers.Add(printer);
+                calculationObsolete.Materials.Add(material);
+                calculationObsolete.Rates.Add(new()
                 {
                     Type = CalculationAttributeType.Tax,
                     IsPercentageValue = true,
                     Value = 19,
                 });
-                _calculation.Rates.Add(new()
+                calculationObsolete.Rates.Add(new()
                 {
                     Type = CalculationAttributeType.Margin,
                     IsPercentageValue = true,
@@ -353,29 +808,29 @@ namespace AndreasReitberger.NUnitTest
                 });
 
                 // Add information
-                _calculation.FailRate = 25;
-                _calculation.EnergyCostsPerkWh = 0.30;
-                _calculation.ApplyEnergyCost = true;
+                calculationObsolete.FailRate = 25;
+                calculationObsolete.EnergyCostsPerkWh = 0.30;
+                calculationObsolete.ApplyEnergyCost = true;
                 // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-                _calculation.PowerLevel = 75;
+                calculationObsolete.PowerLevel = 75;
 
-                _calculation.CalculateCosts();
-                double totalCosts = _calculation.TotalCosts;
-                Assert.That(_calculation.IsCalculated);
+                calculationObsolete.CalculateCosts();
+                double totalCosts = calculationObsolete.TotalCosts;
+                Assert.That(calculationObsolete.IsCalculated);
 
                 List<double> costsCalc = new()
                 {
-                    _calculation.MachineCosts,
-                    _calculation.MaterialCosts,
-                    _calculation.CalculatedMargin,
-                    _calculation.CalculatedTax,
-                    _calculation.ItemsCosts,
+                    calculationObsolete.MachineCosts,
+                    calculationObsolete.MaterialCosts,
+                    calculationObsolete.CalculatedMargin,
+                    calculationObsolete.CalculatedTax,
+                    calculationObsolete.ItemsCosts,
                 };
                 double summedCalc = costsCalc.Sum();
-                Assert.That(Math.Round(summedCalc, 2) == Math.Round(_calculation.TotalCosts, 2));
+                Assert.That(Math.Round(summedCalc, 2) == Math.Round(calculationObsolete.TotalCosts, 2));
 
 
-                Calculation3d _calculation2 = _calculation?.Clone() as Calculation3d;
+                Calculation3d _calculation2 = calculationObsolete?.Clone() as Calculation3d;
                 _calculation2.CalculateCosts();
                 Assert.That(_calculation2.IsCalculated);
                 Assert.That(totalCosts == _calculation2.TotalCosts);
@@ -453,21 +908,21 @@ namespace AndreasReitberger.NUnitTest
                     MultiplyPrintTimeWithQuantity = false
                 };
 
-                _calculation = new Calculation3d();
+                calculationObsolete = new Calculation3d();
                 // Add data
-                _calculation.Files.Add(file);
-                _calculation.Files.Add(file2);
-                _calculation.Printers.Add(printer);
-                _calculation.Materials.Add(material);
+                calculationObsolete.Files.Add(file);
+                calculationObsolete.Files.Add(file2);
+                calculationObsolete.Printers.Add(printer);
+                calculationObsolete.Materials.Add(material);
 
                 // Add information
-                _calculation.FailRate = 25;
-                _calculation.EnergyCostsPerkWh = 0.30;
-                _calculation.ApplyEnergyCost = true;
+                calculationObsolete.FailRate = 25;
+                calculationObsolete.EnergyCostsPerkWh = 0.30;
+                calculationObsolete.ApplyEnergyCost = true;
                 // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-                _calculation.PowerLevel = 75;
+                calculationObsolete.PowerLevel = 75;
 
-                _calculation.CalculateCosts();
+                calculationObsolete.CalculateCosts();
 #if NETFRAMEWORK
                 Calculator3dExporter.Save(_calculation, @"mycalc.3dcx");
                 Calculator3dExporter.Load(@"mycalc.3dcx", out Calculation3d calculation);
@@ -547,21 +1002,21 @@ namespace AndreasReitberger.NUnitTest
                     MultiplyPrintTimeWithQuantity = false
                 };
 
-                _calculation = new Calculation3d();
+                calculationObsolete = new Calculation3d();
                 // Add data
-                _calculation.Files.Add(file);
-                _calculation.Files.Add(file2);
-                _calculation.Printers.Add(printer);
-                _calculation.Materials.Add(material);
+                calculationObsolete.Files.Add(file);
+                calculationObsolete.Files.Add(file2);
+                calculationObsolete.Printers.Add(printer);
+                calculationObsolete.Materials.Add(material);
 
                 // Add information
-                _calculation.FailRate = 25;
-                _calculation.EnergyCostsPerkWh = 0.30;
-                _calculation.ApplyEnergyCost = true;
+                calculationObsolete.FailRate = 25;
+                calculationObsolete.EnergyCostsPerkWh = 0.30;
+                calculationObsolete.ApplyEnergyCost = true;
                 // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-                _calculation.PowerLevel = 75;
+                calculationObsolete.PowerLevel = 75;
 
-                _calculation.ApplyProcedureSpecificAdditions = true;
+                calculationObsolete.ApplyProcedureSpecificAdditions = true;
                 // Needed if the calculation is reloaded later
                 List<CalculationProcedureParameterAddition> additionalInfo = new()
                 {
@@ -587,25 +1042,25 @@ namespace AndreasReitberger.NUnitTest
                     Level = CalculationLevel.Printer,
                 };
                 attributes.AddRange(parameters);
-                _calculation.ProcedureAttributes.Add(attributes);
+                calculationObsolete.ProcedureAttributes.Add(attributes);
 
-                _calculation.CalculateCosts();
+                calculationObsolete.CalculateCosts();
 
-                CalculationAttribute wearCostAttribute = _calculation.OverallPrinterCosts.FirstOrDefault(item =>
-                item.LinkedId == _calculation.Printer.Id &&
+                CalculationAttribute wearCostAttribute = calculationObsolete.OverallPrinterCosts.FirstOrDefault(item =>
+                item.LinkedId == calculationObsolete.Printer.Id &&
                 item.Type == CalculationAttributeType.ProcedureSpecificAddition &&
                 item.Attribute == "NozzleWearCosts"
                 );
                 Assert.That(wearCostAttribute is not null);
 
                 // Updat calculation
-                _calculation.Printer = null;
-                _calculation.Printers.Add(printerSla);
-                _calculation.Printer = _calculation.Printers[^1];
+                calculationObsolete.Printer = null;
+                calculationObsolete.Printers.Add(printerSla);
+                calculationObsolete.Printer = calculationObsolete.Printers[^1];
 
-                _calculation.CalculateCosts();
-                wearCostAttribute = _calculation.OverallPrinterCosts.FirstOrDefault(item =>
-                item.LinkedId == _calculation.Printer.Id &&
+                calculationObsolete.CalculateCosts();
+                wearCostAttribute = calculationObsolete.OverallPrinterCosts.FirstOrDefault(item =>
+                item.LinkedId == calculationObsolete.Printer.Id &&
                 item.Type == CalculationAttributeType.ProcedureSpecificAddition &&
                 item.Attribute == "NozzleWearCosts"
                 );
@@ -696,35 +1151,35 @@ namespace AndreasReitberger.NUnitTest
                     MultiplyPrintTimeWithQuantity = true
                 };
 
-                _calculation = new Calculation3d();
+                calculationObsolete = new Calculation3d();
                 // Add data
-                _calculation.Files.Add(file);
-                _calculation.Files.Add(file2);
-                _calculation.Files.Add(file3);
-                _calculation.Printers.Add(printer);
-                _calculation.Materials.Add(material);
-                _calculation.Materials.Add(material2);
+                calculationObsolete.Files.Add(file);
+                calculationObsolete.Files.Add(file2);
+                calculationObsolete.Files.Add(file3);
+                calculationObsolete.Printers.Add(printer);
+                calculationObsolete.Materials.Add(material);
+                calculationObsolete.Materials.Add(material2);
 
                 // Add information
-                _calculation.FailRate = 25;
-                _calculation.EnergyCostsPerkWh = 0.30;
-                _calculation.ApplyEnergyCost = true;
+                calculationObsolete.FailRate = 25;
+                calculationObsolete.EnergyCostsPerkWh = 0.30;
+                calculationObsolete.ApplyEnergyCost = true;
                 // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-                _calculation.PowerLevel = 75;
+                calculationObsolete.PowerLevel = 75;
 
-                _calculation.CalculateCosts();
+                calculationObsolete.CalculateCosts();
 
-                double total = _calculation.GetTotalCosts();
+                double total = calculationObsolete.GetTotalCosts();
 
-                var materialCosts = PrintCalculator3d.GetMaterialCosts(_calculation);
-                var machineCosts = PrintCalculator3d.GetMachineCosts(_calculation);
+                var materialCosts = PrintCalculator3d.GetMaterialCosts(calculationObsolete);
+                var machineCosts = PrintCalculator3d.GetMachineCosts(calculationObsolete);
 
-                _calculation.DifferFileCosts = true;
-                _calculation.CalculateCosts();
+                calculationObsolete.DifferFileCosts = true;
+                calculationObsolete.CalculateCosts();
 
-                double totalDiffer = _calculation.GetTotalCosts();
+                double totalDiffer = calculationObsolete.GetTotalCosts();
 
-                Assert.That(_calculation.IsCalculated);
+                Assert.That(calculationObsolete.IsCalculated);
                 Assert.That(total == totalDiffer);
             }
             catch (Exception exc)
@@ -982,15 +1437,15 @@ namespace AndreasReitberger.NUnitTest
                 LinkedToFile = false,
             };
 
-            _calculation = new Calculation3d();
+            calculationObsolete = new Calculation3d();
             // Add data
-            _calculation.AdditionalItems.Add(usage);
-            _calculation.Files.Add(file);
-            _calculation.Files.Add(file2);
-            _calculation.Printers.Add(printer);
-            _calculation.Printers.Add(printer2);
-            _calculation.Materials.Add(material);
-            _calculation.Materials.Add(material2);
+            calculationObsolete.AdditionalItems.Add(usage);
+            calculationObsolete.Files.Add(file);
+            calculationObsolete.Files.Add(file2);
+            calculationObsolete.Printers.Add(printer);
+            calculationObsolete.Printers.Add(printer2);
+            calculationObsolete.Materials.Add(material);
+            calculationObsolete.Materials.Add(material2);
             // Hardware replacement costs
             ProcedureAddition resinTank = new()
             {
@@ -1030,18 +1485,18 @@ namespace AndreasReitberger.NUnitTest
                     QuantityInPackage = 100,
                 });
 
-            _calculation.ProcedureAdditions.Add(resinTank);
-            _calculation.ProcedureAdditions.Add(gloves);
+            calculationObsolete.ProcedureAdditions.Add(resinTank);
+            calculationObsolete.ProcedureAdditions.Add(gloves);
 
             // Add information
-            _calculation.FailRate = 25;
-            _calculation.EnergyCostsPerkWh = 0.30;
-            _calculation.ApplyEnergyCost = true;
+            calculationObsolete.FailRate = 25;
+            calculationObsolete.EnergyCostsPerkWh = 0.30;
+            calculationObsolete.ApplyEnergyCost = true;
             // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-            _calculation.PowerLevel = 75;
+            calculationObsolete.PowerLevel = 75;
 
-            _calculation.CalculateCosts();
-            return _calculation;
+            calculationObsolete.CalculateCosts();
+            return calculationObsolete;
         }
 
         [Test]

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
@@ -13,10 +13,10 @@ namespace AndreasReitberger.NUnitTest
 {
     public class TestsRealm
     {
-        bool ApplyResinGlovesCosts = true;
-        bool ApplyResinWashingCosts = true;
-        bool ApplyResinFilterCosts = true;
-        bool ApplyResinTankWearCosts = true;
+        bool ApplyResinGlovesCosts = false;
+        bool ApplyResinWashingCosts = false;
+        bool ApplyResinFilterCosts = false;
+        bool ApplyResinTankWearCosts = false;
 
         Calculation3dEnhanced? calculation;
 
@@ -304,6 +304,7 @@ namespace AndreasReitberger.NUnitTest
                         PerFile = false,
                         PerPiece = false,
                     };
+                    // Causes an exception. Must be investigated
                     foreach(var para in parameters)
                         parameters.Add(para);
                     calculation.ProcedureAttributes.Add(cpa1);

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Sqlite.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Sqlite.cs
@@ -1429,7 +1429,7 @@ namespace AndreasReitberger.NUnitTest
                     Print3dInfo info = new()
                     {
                         File = file,
-                        MaterialUsages = [new() { Material = material, Percentage = 1 }],
+                        MaterialUsages = [new() { Material = material, PercentageValue = 1 }],
                         Printer = printer,
                         Items = [usage],
                     };
@@ -1438,7 +1438,7 @@ namespace AndreasReitberger.NUnitTest
                     {
                         File = file2,
                         // Multi-Material for one file
-                        MaterialUsages = [new() { Material = material, Percentage = 0.5 }, new() { Material = material2, Percentage = 0.5 }],
+                        MaterialUsages = [new() { Material = material, PercentageValue = 0.5 }, new() { Material = material2, PercentageValue = 0.5 }],
                         Printer = printer2,
                     };
                     await DatabaseHandler.Instance.SetPrintInfoWithChildrenAsync(info2);
@@ -1584,7 +1584,7 @@ namespace AndreasReitberger.NUnitTest
                     Print3dInfo info = new()
                     {
                         File = file,
-                        MaterialUsages = [new() { Material = material, Percentage = 1 }],
+                        MaterialUsages = [new() { Material = material, PercentageValue = 1 }],
                         Printer = printer,
                         Items = [usage],
                     };
@@ -1592,7 +1592,7 @@ namespace AndreasReitberger.NUnitTest
                     {
                         File = file2,
                         // Multi-Material for one file
-                        MaterialUsages = [new() { Material = material, Percentage = 0.5 }, new() { Material = material2, Percentage = 0.5 }],
+                        MaterialUsages = [new() { Material = material, PercentageValue = 0.5 }, new() { Material = material2, PercentageValue = 0.5 }],
                         Printer = printer2,
                     };
 

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Sqlite.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Sqlite.cs
@@ -1594,7 +1594,7 @@ namespace AndreasReitberger.NUnitTest
 
                     // Recreate tables
                     await DatabaseHandler.Instance.RebuildAllTableAsync();
-                    await Task.Delay(250);
+                    await Task.Delay(500);
 
                     double startAmount = 0;
                     Material3d material = new()
@@ -1765,7 +1765,7 @@ namespace AndreasReitberger.NUnitTest
 
                     // Recreate tables
                     await DatabaseHandler.Instance.RebuildAllTableAsync();
-                    await Task.Delay(250);
+                    await Task.Delay(500);
 
                     Manufacturer manufacturer = new()
                     {
@@ -1932,7 +1932,7 @@ namespace AndreasReitberger.NUnitTest
 
                     // Recreate tables
                     await DatabaseHandler.Instance.RebuildAllTableAsync();
-                    await Task.Delay(250);
+                    await Task.Delay(500);
 
                     Manufacturer manufacturer = new()
                     {

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Sqlite.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Sqlite.cs
@@ -1,21 +1,469 @@
 using AndreasReitberger.Print3d.Enums;
-using AndreasReitberger.Print3d.SQLite.PrinterAdditions;
 using AndreasReitberger.Print3d.SQLite;
 using AndreasReitberger.Print3d.SQLite.CalculationAdditions;
+using AndreasReitberger.Print3d.SQLite.CustomerAdditions;
 using AndreasReitberger.Print3d.SQLite.MaterialAdditions;
 using AndreasReitberger.Print3d.SQLite.ProcedureAdditions;
 using AndreasReitberger.Print3d.SQLite.StorageAdditions;
+using AndreasReitberger.Print3d.SQLite.WorkstepAdditions;
 using NUnit.Framework;
 using SQLite;
-using AndreasReitberger.Print3d.SQLite.WorkstepAdditions;
 
 namespace AndreasReitberger.NUnitTest
 {
     public class TestsSqlite
     {
+        bool ApplyResinGlovesCosts = true;
+        bool ApplyResinWashingCosts = true;
+        bool ApplyResinFilterCosts = true;
+        bool ApplyResinTankWearCosts = true;
+
+        Calculation3dEnhanced? calculation;
+
         [SetUp]
         public void Setup()
         {
+            Printer3d printerFDM = new Printer3d()
+            {
+                Type = Printer3dType.FDM,
+                Model = "i3 MK3S",
+                PowerConsumption = 210,
+                Price = 899,
+                MaterialType = Material3dFamily.Filament,
+            };
+            Printer3d printerDLP = new Printer3d()
+            {
+                Type = Printer3dType.DLP,
+                Model = "Photon X",
+                PowerConsumption = 160,
+                Price = 599,
+                MaterialType = Material3dFamily.Resin,
+            };
+
+            calculation = new Calculation3dEnhanced()
+            {
+                Name = "Test",
+                Customer = new Customer3d()
+                {
+                    Name = "Max",
+                    LastName = "Mustermann",
+                    IsCompany = false,
+                    EmailAddresses =
+                    [
+                        new Email()
+                        {
+                            EmailAddress = "max.mustermann@example.com"
+                        },
+                    ],
+                    Addresses = [
+                        new Address()
+                        {
+                            City = "Muserstadt",
+                            Zip = "93426",
+                            CountryCode = "de",
+                            Street = "Musterstraße 4",
+                        }
+                    ],
+                },
+                PrintInfos = [
+                    // FDM job
+                    new Print3dInfo()
+                    {
+                        Name = "My awesome print job",
+                        File = new File3d()
+                        {
+                            FileName = "my.gcode",
+                            PrintTime = 5.263,
+                            Volume = 35.54,
+                            Quantity = 5,
+                        },
+                        MaterialUsages = [
+                            new Material3dUsage()
+                            {
+                                Material = new Material3d()
+                                {
+                                    Name = "Prusament PETG 1kg JetBlack",
+                                    Density = 1.24,
+                                    ColorCode = "#000000",
+                                    MaterialFamily = Material3dFamily.Filament,
+                                    TypeOfMaterial = new Material3dType() { Family = Material3dFamily.Filament, Material = "PETG" },
+                                    PackageSize = 1,
+                                    Unit = Unit.Kilogram,
+                                    UnitPrice = 30,
+                                    Manufacturer = new Manufacturer()
+                                    {
+                                        Name = "Prusa",
+                                    }
+                                },
+                                PercentageValue = 0.5,
+                            },
+                            new Material3dUsage()
+                            {
+                                Material = new Material3d()
+                                {
+                                    Name = "Prusament PLA 1kg JetBlack",
+                                    Density = 1.24,
+                                    ColorCode = "#000000",
+                                    MaterialFamily = Material3dFamily.Filament,
+                                    TypeOfMaterial = new Material3dType() { Family = Material3dFamily.Filament, Material = "PLA" },
+                                    PackageSize = 1,
+                                    Unit = Unit.Kilogram,
+                                    UnitPrice = 25,
+                                    Manufacturer = new Manufacturer()
+                                    {
+                                        Name = "Prusa",
+                                    }
+                                },
+                                PercentageValue = 0.5,
+                            }
+                        ],
+                        Printer = printerFDM,
+                        Items = [
+                            new Item3dUsage()
+                            {
+                                Item = new Item3d()
+                                {
+                                    Name = "M3x16 Screws",
+                                    PackagePrice = 20,
+                                    PackageSize = 100,
+                                },
+                                Quantity = 10,
+                            },
+                        ]
+                    },
+                    // Resing job
+                    new Print3dInfo()
+                    {
+                        Name = "My first resin print job",
+                        File = new File3d()
+                        {
+                            FileName = "Batman.dlp",
+                            PrintTime = 2.65,
+                            Volume = 65.546,
+                            Quantity = 20,
+                        },
+                        MaterialUsages = [
+                            new Material3dUsage()
+                            {
+                                Material = new Material3d()
+                                {
+                                    Name = "Anycubic Tough Resin",
+                                    Density = 1.11,
+                                    ColorCode = "#000000",
+                                    MaterialFamily = Material3dFamily.Resin,
+                                    TypeOfMaterial = new Material3dType() { Family = Material3dFamily.Resin, Material = "TOUGH" },
+                                    PackageSize = 1,
+                                    Unit = Unit.Liters,
+                                    UnitPrice = 65,
+                                    Manufacturer = new Manufacturer()
+                                    {
+                                        Name = "Anycubic",
+                                    }
+                                },
+                                PercentageValue = 1,
+                            }
+                        ],
+                        Printer = printerDLP,
+                    },
+                    new Print3dInfo()
+                    {
+                        Name = "My first resin print job",
+                        File = new File3d()
+                        {
+                            FileName = "Superman.dlp",
+                            PrintTime = 1.42,
+                            Volume = 35.4536,
+                            Quantity = 3,
+                        },
+                        MaterialUsages = [
+                            new Material3dUsage()
+                            {
+                                Material = new Material3d()
+                                {
+                                    Name = "Anycubic Tough Resin",
+                                    Density = 1.11,
+                                    ColorCode = "#000000",
+                                    MaterialFamily = Material3dFamily.Resin,
+                                    TypeOfMaterial = new Material3dType() { Family = Material3dFamily.Resin, Material = "TOUGH" },
+                                    PackageSize = 1,
+                                    Unit = Unit.Liters,
+                                    UnitPrice = 65,
+                                    Manufacturer = new Manufacturer()
+                                    {
+                                        Name = "Anycubic",
+                                    }
+                                },
+                                PercentageValue = 1,
+                            }
+                        ],
+                        Printer = printerDLP,
+                    }
+                ],
+                WorkstepUsages = [
+                    new WorkstepUsage()
+                    {
+                        Workstep = new Workstep()
+                        {
+                            Name = "Cleanup",
+                            CalculationType = CalculationType.PerPiece,
+                            Category = new WorkstepCategory() { Name = "Post-Processing" },
+                            Price = 0.5,
+                            Note = "Contains the removal of supports and general cleanup",
+                            Type = WorkstepType.Post,
+                        },
+                        UsageParameter = new WorkstepUsageParameter()
+                        {
+                            ParameterType = WorkstepUsageParameterType.Quantity,
+                            Value = 1,
+                        }
+                    },
+                    new WorkstepUsage()
+                    {
+                        Workstep = new Workstep()
+                        {
+                            Name = "Packaging",
+                            CalculationType = CalculationType.PerJob,
+                            Category = new WorkstepCategory() { Name = "Post-Processing" },
+                            Price = 1,
+                            Note = "Contains the packaging of the prints",
+                            Type = WorkstepType.Post,
+                        },
+                        UsageParameter = new WorkstepUsageParameter()
+                        {
+                            ParameterType = WorkstepUsageParameterType.Quantity,
+                            Value = 1,
+                        }
+                    }
+                    ],
+                ApplyEnergyCost = true,
+                PowerLevel = 75,
+                EnergyCostsPerkWh = 0.4,
+                AdditionalItems = [
+                    new Item3dUsage()
+                    {
+                        Item = new Item3d()
+                        {
+
+                            Name = "Nuts M3",
+                            PackageSize = 100,
+                            PackagePrice = 9.99d,
+                            Manufacturer = new Manufacturer()
+                            {
+                                Name = "Würth",
+                                DebitorNumber = "DE26265126",
+                                Website = "https://www.wuerth.de/",
+                            },
+                            SKU = "2302423-1223"
+                        },
+                        Quantity = 2,
+                    },
+                    new Item3dUsage()
+                    {
+                        Item = new Item3d()
+                        {
+                            Name = "Screws M3 20mm",
+                            PackageSize = 50,
+                            PackagePrice = 14.99d,
+                            Manufacturer = new Manufacturer()
+                            {
+                                Name = "Würth",
+                                DebitorNumber = "DE26265126",
+                                Website = "https://www.wuerth.de/",
+                            },
+                            SKU = "2302423-6413"
+                        },
+                        Quantity = 2,
+                    }
+                    ],
+                FailRate = 5,
+                State = CalculationState.Draft,
+                ApplyProcedureSpecificAdditions = true,
+            };
+
+            List<CalculationProcedureParameter> parameters = [];
+            List<CalculationProcedureParameterAddition> additionalInfo = [];
+
+            if (ApplyResinGlovesCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                        new CalculationProcedureParameterAddition("amount", 100),
+                        new CalculationProcedureParameterAddition("price", 25),
+                        new CalculationProcedureParameterAddition("perjob", 2),
+                    ];
+
+                    parameters =
+                    [
+                        new CalculationProcedureParameter()
+                        {
+                            Type = ProcedureParameter.GloveCosts,
+                            Value = 2d * (25d / 100d),
+                            Additions = additionalInfo,
+                        }
+                    ];
+                    calculation.ProcedureAttributes.Add(
+                        new CalculationProcedureAttribute()
+                        {
+                            Attribute = ProcedureAttribute.GlovesCosts,
+                            Family = Material3dFamily.Resin,
+                            Parameters = parameters,
+                            Level = CalculationLevel.Printer,
+                            PerFile = false,
+                            PerPiece = false,
+                        });
+                }
+            }
+            if (ApplyResinWashingCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                        new CalculationProcedureParameterAddition("amount", 5),
+                        new CalculationProcedureParameterAddition("price", 50),
+                        new CalculationProcedureParameterAddition("perjob", 0.1d),
+                    ];
+
+                    parameters =
+                    [
+                        new CalculationProcedureParameter()
+                        {
+                            Type = ProcedureParameter.WashingCosts,
+                            Value = 0.1d * (50d / 5d),
+                            Additions = additionalInfo,
+                        }
+                    ];
+                    calculation.ProcedureAttributes.Add(
+                        new CalculationProcedureAttribute()
+                        {
+                            Attribute = ProcedureAttribute.WashingCosts,
+                            Family = Material3dFamily.Resin,
+                            Parameters = parameters,
+                            Level = CalculationLevel.Printer,
+                            PerPiece = true,
+                            PerFile = true,
+                        });
+                }
+            }
+            if (ApplyResinFilterCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                        new CalculationProcedureParameterAddition("amount", 50),
+                        new CalculationProcedureParameterAddition("price", 25),
+                        new CalculationProcedureParameterAddition("perjob", 1),
+                    ];
+
+                    parameters =
+                    [
+                        new CalculationProcedureParameter()
+                        {
+                            Type = ProcedureParameter.FilterCosts,
+                            Value = 1d * (25d / 50d),
+                            Additions = additionalInfo,
+                        }
+                    ];
+                    calculation.ProcedureAttributes.Add(
+                        new CalculationProcedureAttribute()
+                        {
+                            Attribute = ProcedureAttribute.FilterCosts,
+                            Family = Material3dFamily.Resin,
+                            Parameters = parameters,
+                            Level = CalculationLevel.Printer,
+                            PerFile = true,
+                            PerPiece = false,
+                        });
+                }
+            }
+            if (ApplyResinTankWearCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                            new CalculationProcedureParameterAddition("replacementcosts", 120),
+                            new CalculationProcedureParameterAddition("wearfactor", 0.01d)
+                    ];
+                    parameters =
+                    [
+                        new CalculationProcedureParameter()
+                        {
+                            Type = ProcedureParameter.ResinTankWearCosts,
+                            Value = 120d  * 0.01d,
+                            Additions = additionalInfo,
+
+                        }
+                    ];
+                    calculation.ProcedureAttributes.Add(
+                        new CalculationProcedureAttribute()
+                        {
+                            Attribute = ProcedureAttribute.ResinTankWear,
+                            Family = Material3dFamily.Resin,
+                            Parameters = parameters,
+                            Level = CalculationLevel.Printer,
+                            PerPiece = false,
+                            PerFile = true,
+                        });
+                }
+            }
+        }
+
+        [Test]
+        public void TestProcedureSpecificAddition()
+        {
+            try
+            {
+                Assert.That(calculation is not null);
+                Assert.That(calculation?.ProcedureAttributes?.Count > 0);
+                calculation.ApplyProcedureSpecificAdditions = false;
+                calculation.CalculateCosts();
+                var total = calculation.TotalCosts;
+
+                calculation.ApplyProcedureSpecificAdditions = true;
+                calculation.CalculateCosts();
+                var total2 = calculation.TotalCosts;
+                Assert.That(total < total2);
+
+                /*
+                 * GloveCosts: Should be available only once per machine and print job
+                 * FilterCosts: Should be available once per print job info
+                 * WashingCosts: Are per print job info and file quantity
+                 */
+
+                var gloveCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "GloveCosts")?.ToList();
+                Assert.That(gloveCosts?.Count == calculation.AvailablePrinters.Where(printer => printer.MaterialType == Material3dFamily.Resin).Count());
+                Assert.That(gloveCosts?.Sum(c => c.Value) == 0.5d);
+
+                int fileCount = calculation.PrintInfos.Where(pi => pi.Printer.MaterialType == Material3dFamily.Resin).Count();
+
+                var filterCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "FilterCosts")?.ToList();
+                Assert.That(filterCosts?.Count == fileCount);
+                Assert.That(filterCosts?.Sum(c => c.Value) == 1d);
+
+                var washingCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "WashingCosts")?.ToList();
+                Assert.That(washingCosts?.Count == fileCount);
+                foreach (var washCost in washingCosts)
+                {
+                    File3d f = calculation.PrintInfos.FirstOrDefault(pi => pi.File.Id == washCost.FileId).File;
+                    Assert.That(washCost.Value / f.Quantity == 1d);
+                }
+
+                var tankWearCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "ResinTankWearCosts")?.ToList();
+                Assert.That(tankWearCosts?.Count == fileCount);
+                Assert.That(tankWearCosts?.Sum(c => c.Value) == 2.4d);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message);
+            }
         }
 
         [Test]
@@ -267,7 +715,7 @@ namespace AndreasReitberger.NUnitTest
             Assert.That(mappings?.Count > 0);
         }
 
-        private Calculation3d _calculation;
+        private Calculation3d calculationObsolete;
         [Test]
         public void TestCalculation()
         {
@@ -341,20 +789,20 @@ namespace AndreasReitberger.NUnitTest
                     LinkedToFile = false,
                 };
 
-                _calculation = new();
+                calculationObsolete = new();
                 // Add data
-                _calculation.AdditionalItems.Add(usage);
-                _calculation.Files.Add(file);
-                _calculation.Files.Add(file2);
-                _calculation.Printers.Add(printer);
-                _calculation.Materials.Add(material);
-                _calculation.Rates.Add(new()
+                calculationObsolete.AdditionalItems.Add(usage);
+                calculationObsolete.Files.Add(file);
+                calculationObsolete.Files.Add(file2);
+                calculationObsolete.Printers.Add(printer);
+                calculationObsolete.Materials.Add(material);
+                calculationObsolete.Rates.Add(new()
                 {
                     Type = CalculationAttributeType.Tax,
                     IsPercentageValue = true,
                     Value = 19,
                 });
-                _calculation.Rates.Add(new()
+                calculationObsolete.Rates.Add(new()
                 {
                     Type = CalculationAttributeType.Margin,
                     IsPercentageValue = true,
@@ -362,29 +810,29 @@ namespace AndreasReitberger.NUnitTest
                 });
 
                 // Add information
-                _calculation.FailRate = 25;
-                _calculation.EnergyCostsPerkWh = 0.30;
-                _calculation.ApplyEnergyCost = true;
+                calculationObsolete.FailRate = 25;
+                calculationObsolete.EnergyCostsPerkWh = 0.30;
+                calculationObsolete.ApplyEnergyCost = true;
                 // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-                _calculation.PowerLevel = 75;
+                calculationObsolete.PowerLevel = 75;
 
-                _calculation.CalculateCosts();
-                double totalCosts = _calculation.TotalCosts;
-                Assert.That(_calculation.IsCalculated);
+                calculationObsolete.CalculateCosts();
+                double totalCosts = calculationObsolete.TotalCosts;
+                Assert.That(calculationObsolete.IsCalculated);
 
                 List<double> costsCalc = new()
                 {
-                    _calculation.MachineCosts,
-                    _calculation.MaterialCosts,
-                    _calculation.CalculatedMargin,
-                    _calculation.CalculatedTax,
-                    _calculation.ItemsCost,
+                    calculationObsolete.MachineCosts,
+                    calculationObsolete.MaterialCosts,
+                    calculationObsolete.CalculatedMargin,
+                    calculationObsolete.CalculatedTax,
+                    calculationObsolete.ItemsCost,
                 };
                 double summedCalc = costsCalc.Sum();
-                Assert.That(Math.Round(summedCalc, 2) == Math.Round(_calculation.TotalCosts, 2));
+                Assert.That(Math.Round(summedCalc, 2) == Math.Round(calculationObsolete.TotalCosts, 2));
 
 
-                Calculation3d _calculation2 = _calculation?.Clone() as Calculation3d;
+                Calculation3d _calculation2 = calculationObsolete?.Clone() as Calculation3d;
                 _calculation2.CalculateCosts();
                 Assert.That(_calculation2.IsCalculated);
                 Assert.That(totalCosts == _calculation2.TotalCosts);
@@ -462,21 +910,21 @@ namespace AndreasReitberger.NUnitTest
                     MultiplyPrintTimeWithQuantity = false
                 };
 
-                _calculation = new Calculation3d();
+                calculationObsolete = new Calculation3d();
                 // Add data
-                _calculation.Files.Add(file);
-                _calculation.Files.Add(file2);
-                _calculation.Printers.Add(printer);
-                _calculation.Materials.Add(material);
+                calculationObsolete.Files.Add(file);
+                calculationObsolete.Files.Add(file2);
+                calculationObsolete.Printers.Add(printer);
+                calculationObsolete.Materials.Add(material);
 
                 // Add information
-                _calculation.FailRate = 25;
-                _calculation.EnergyCostsPerkWh = 0.30;
-                _calculation.ApplyEnergyCost = true;
+                calculationObsolete.FailRate = 25;
+                calculationObsolete.EnergyCostsPerkWh = 0.30;
+                calculationObsolete.ApplyEnergyCost = true;
                 // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-                _calculation.PowerLevel = 75;
+                calculationObsolete.PowerLevel = 75;
 
-                _calculation.CalculateCosts();
+                calculationObsolete.CalculateCosts();
 #if NETFRAMEWORK
                 Calculator3dExporter.Save(_calculation, @"mycalc.3dcx");
                 Calculator3dExporter.Load(@"mycalc.3dcx", out Calculation3d calculation);
@@ -556,21 +1004,21 @@ namespace AndreasReitberger.NUnitTest
                     MultiplyPrintTimeWithQuantity = false
                 };
 
-                _calculation = new Calculation3d();
+                calculationObsolete = new Calculation3d();
                 // Add data
-                _calculation.Files.Add(file);
-                _calculation.Files.Add(file2);
-                _calculation.Printers.Add(printer);
-                _calculation.Materials.Add(material);
+                calculationObsolete.Files.Add(file);
+                calculationObsolete.Files.Add(file2);
+                calculationObsolete.Printers.Add(printer);
+                calculationObsolete.Materials.Add(material);
 
                 // Add information
-                _calculation.FailRate = 25;
-                _calculation.EnergyCostsPerkWh = 0.30;
-                _calculation.ApplyEnergyCost = true;
+                calculationObsolete.FailRate = 25;
+                calculationObsolete.EnergyCostsPerkWh = 0.30;
+                calculationObsolete.ApplyEnergyCost = true;
                 // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-                _calculation.PowerLevel = 75;
+                calculationObsolete.PowerLevel = 75;
 
-                _calculation.ApplyProcedureSpecificAdditions = true;
+                calculationObsolete.ApplyProcedureSpecificAdditions = true;
                 // Needed if the calculation is reloaded later
                 List<CalculationProcedureParameterAddition> additionalInfo =
                 [
@@ -589,7 +1037,7 @@ namespace AndreasReitberger.NUnitTest
                     }
                 };
 
-                _calculation.ProcedureAttributes.Add(
+                calculationObsolete.ProcedureAttributes.Add(
                     new CalculationProcedureAttribute()
                     {
                         Attribute = ProcedureAttribute.NozzleWear,
@@ -599,23 +1047,23 @@ namespace AndreasReitberger.NUnitTest
                     }
                 );
 
-                _calculation.CalculateCosts();
+                calculationObsolete.CalculateCosts();
 
-                CalculationAttribute? wearCostAttribute = _calculation.OverallPrinterCosts.FirstOrDefault(item =>
+                CalculationAttribute? wearCostAttribute = calculationObsolete.OverallPrinterCosts.FirstOrDefault(item =>
                 item.Type == CalculationAttributeType.ProcedureSpecificAddition &&
                 item.Attribute == "NozzleWearCosts"
                 );
                 Assert.That(wearCostAttribute is not null);
 
                 // Updat calculation
-                _calculation.Printer = null;
-                _calculation.Printers =
+                calculationObsolete.Printer = null;
+                calculationObsolete.Printers =
                 [
                     printerSla
                 ];
 
-                _calculation.CalculateCosts();
-                wearCostAttribute = _calculation.OverallPrinterCosts.FirstOrDefault(item =>
+                calculationObsolete.CalculateCosts();
+                wearCostAttribute = calculationObsolete.OverallPrinterCosts.FirstOrDefault(item =>
                 item.Type == CalculationAttributeType.ProcedureSpecificAddition &&
                 item.Attribute == "NozzleWearCosts"
                 );
@@ -928,19 +1376,19 @@ namespace AndreasReitberger.NUnitTest
 
             };
 
-            _calculation = new Calculation3d()
+            calculationObsolete = new Calculation3d()
             {
                 Name = "My awesome calculation"
             };
             // Add data
-            _calculation.AdditionalItems.Add(usage);
-            _calculation.Files.Add(file);
-            _calculation.Files.Add(file2);
-            _calculation.Printers.Add(printer);
-            _calculation.Printers.Add(printer2);
-            _calculation.Materials.Add(material);
-            _calculation.Materials.Add(material2);
-            _calculation.ProcedureAdditions.Add(new ProcedureAddition()
+            calculationObsolete.AdditionalItems.Add(usage);
+            calculationObsolete.Files.Add(file);
+            calculationObsolete.Files.Add(file2);
+            calculationObsolete.Printers.Add(printer);
+            calculationObsolete.Printers.Add(printer2);
+            calculationObsolete.Materials.Add(material);
+            calculationObsolete.Materials.Add(material2);
+            calculationObsolete.ProcedureAdditions.Add(new ProcedureAddition()
             {
                 Name = "Resin Tank Replacement",
                 Description = "Take the costs for the resin tank replacement into account?",
@@ -959,7 +1407,7 @@ namespace AndreasReitberger.NUnitTest
                     }
                 }
             });
-            _calculation.ProcedureAdditions.Add(new ProcedureAddition()
+            calculationObsolete.ProcedureAdditions.Add(new ProcedureAddition()
             {
                 Name = "Gloves",
                 Description = "Take the costs for the gloves?",
@@ -980,14 +1428,14 @@ namespace AndreasReitberger.NUnitTest
             });
 
             // Add information
-            _calculation.FailRate = 25;
-            _calculation.EnergyCostsPerkWh = 0.30;
-            _calculation.ApplyEnergyCost = true;
+            calculationObsolete.FailRate = 25;
+            calculationObsolete.EnergyCostsPerkWh = 0.30;
+            calculationObsolete.ApplyEnergyCost = true;
             // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-            _calculation.PowerLevel = 75;
+            calculationObsolete.PowerLevel = 75;
 
-            _calculation.CalculateCosts();
-            return _calculation;
+            calculationObsolete.CalculateCosts();
+            return calculationObsolete;
         }
 
         public void MultiFileDifferTest()
@@ -1088,37 +1536,37 @@ namespace AndreasReitberger.NUnitTest
                     LinkedToFile = false,
                 };
 
-                _calculation = new Calculation3d();
+                calculationObsolete = new Calculation3d();
                 // Add data
-                _calculation.Files.Add(file);
-                _calculation.Files.Add(file2);
-                _calculation.Files.Add(file3);
-                _calculation.Printers.Add(printer);
-                _calculation.Materials.Add(material);
-                _calculation.Materials.Add(material2);
+                calculationObsolete.Files.Add(file);
+                calculationObsolete.Files.Add(file2);
+                calculationObsolete.Files.Add(file3);
+                calculationObsolete.Printers.Add(printer);
+                calculationObsolete.Materials.Add(material);
+                calculationObsolete.Materials.Add(material2);
 
-                _calculation.AdditionalItems.Add(usage);
+                calculationObsolete.AdditionalItems.Add(usage);
 
                 // Add information
-                _calculation.FailRate = 25;
-                _calculation.EnergyCostsPerkWh = 0.30;
-                _calculation.ApplyEnergyCost = true;
+                calculationObsolete.FailRate = 25;
+                calculationObsolete.EnergyCostsPerkWh = 0.30;
+                calculationObsolete.ApplyEnergyCost = true;
                 // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-                _calculation.PowerLevel = 75;
+                calculationObsolete.PowerLevel = 75;
 
-                _calculation.CalculateCosts();
+                calculationObsolete.CalculateCosts();
 
-                double total = _calculation.GetTotalCosts();
+                double total = calculationObsolete.GetTotalCosts();
 
-                var materialCosts = PrintCalculator3d.GetMaterialCosts(_calculation);
-                var machineCosts = PrintCalculator3d.GetMachineCosts(_calculation);
+                var materialCosts = PrintCalculator3d.GetMaterialCosts(calculationObsolete);
+                var machineCosts = PrintCalculator3d.GetMachineCosts(calculationObsolete);
 
-                _calculation.DifferFileCosts = true;
-                _calculation.CalculateCosts();
+                calculationObsolete.DifferFileCosts = true;
+                calculationObsolete.CalculateCosts();
 
-                double totalDiffer = _calculation.GetTotalCosts();
+                double totalDiffer = calculationObsolete.GetTotalCosts();
 
-                Assert.That(_calculation.IsCalculated);
+                Assert.That(calculationObsolete.IsCalculated);
                 Assert.That(total == totalDiffer);
             }
             catch (Exception exc)

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
@@ -2,6 +2,7 @@ using AndreasReitberger.Print3d;
 using AndreasReitberger.Print3d.Enums;
 using AndreasReitberger.Print3d.Models;
 using AndreasReitberger.Print3d.Models.CalculationAdditions;
+using AndreasReitberger.Print3d.Models.CustomerAdditions;
 using AndreasReitberger.Print3d.Models.MaterialAdditions;
 using AndreasReitberger.Print3d.Models.WorkstepAdditions;
 using AndreasReitberger.Print3d.ProcedureAdditions;
@@ -11,12 +12,460 @@ namespace AndreasReitberger.NUnitTest
 {
     public class Tests
     {
+        bool ApplyResinGlovesCosts = true;
+        bool ApplyResinWashingCosts = true;
+        bool ApplyResinFilterCosts = true;
+        bool ApplyResinTankWearCosts = true;
+
+        Calculation3dEnhanced? calculation;
+
         [SetUp]
         public void Setup()
         {
+            Printer3d printerFDM = new Printer3d()
+            {
+                Type = Printer3dType.FDM,
+                Model = "i3 MK3S",
+                PowerConsumption = 210,
+                Price = 899,
+                MaterialType = Material3dFamily.Filament,
+            };
+            Printer3d printerDLP = new Printer3d()
+            {
+                Type = Printer3dType.DLP,
+                Model = "Photon X",
+                PowerConsumption = 160,
+                Price = 599,
+                MaterialType = Material3dFamily.Resin,
+            };
+
+            calculation = new Calculation3dEnhanced()
+            {
+                Name = "Test",
+                Customer = new Customer3d()
+                {
+                    Name = "Max",
+                    LastName = "Mustermann",
+                    IsCompany = false,
+                    EmailAddresses =
+                    [
+                        new Email()
+                        {
+                            EmailAddress = "max.mustermann@example.com"
+                        },
+                    ],
+                    Addresses = [
+                        new Address()
+                        {
+                            City = "Muserstadt",
+                            Zip = "93426",
+                            CountryCode = "de",
+                            Street = "Musterstraße 4",
+                        }
+                    ],
+                },
+                PrintInfos = [
+                    // FDM job
+                    new Print3dInfo()
+                    {
+                        Name = "My awesome print job",
+                        File = new File3d()
+                        {
+                            FileName = "my.gcode",
+                            PrintTime = 5.263,
+                            Volume = 35.54,
+                            Quantity = 5,
+                        },
+                        MaterialUsages = [
+                            new Material3dUsage()
+                            {
+                                Material = new Material3d()
+                                {
+                                    Name = "Prusament PETG 1kg JetBlack",
+                                    Density = 1.24,
+                                    ColorCode = "#000000",
+                                    MaterialFamily = Material3dFamily.Filament,
+                                    TypeOfMaterial = new Material3dType() { Family = Material3dFamily.Filament, Material = "PETG" },
+                                    PackageSize = 1,
+                                    Unit = Unit.Kilogram,
+                                    UnitPrice = 30,
+                                    Manufacturer = new Manufacturer()
+                                    {
+                                        Name = "Prusa",
+                                    }
+                                },
+                                PercentageValue = 0.5,
+                            },
+                            new Material3dUsage()
+                            {
+                                Material = new Material3d()
+                                {
+                                    Name = "Prusament PLA 1kg JetBlack",
+                                    Density = 1.24,
+                                    ColorCode = "#000000",
+                                    MaterialFamily = Material3dFamily.Filament,
+                                    TypeOfMaterial = new Material3dType() { Family = Material3dFamily.Filament, Material = "PLA" },
+                                    PackageSize = 1,
+                                    Unit = Unit.Kilogram,
+                                    UnitPrice = 25,
+                                    Manufacturer = new Manufacturer()
+                                    {
+                                        Name = "Prusa",
+                                    }
+                                },
+                                PercentageValue = 0.5,
+                            }
+                        ],
+                        Printer = printerFDM,
+                        Items = [
+                            new Item3dUsage()
+                            {
+                                Item = new Item3d()
+                                {
+                                    Name = "M3x16 Screws",
+                                    PackagePrice = 20,
+                                    PackageSize = 100,
+                                },
+                                Quantity = 10,
+                            },
+                        ]
+                    },
+                    // Resing job
+                    new Print3dInfo()
+                    {
+                        Name = "My first resin print job",
+                        File = new File3d()
+                        {
+                            FileName = "Batman.dlp",
+                            PrintTime = 2.65,
+                            Volume = 65.546,
+                            Quantity = 20,
+                        },
+                        MaterialUsages = [
+                            new Material3dUsage()
+                            {
+                                Material = new Material3d()
+                                {
+                                    Name = "Anycubic Tough Resin",
+                                    Density = 1.11,
+                                    ColorCode = "#000000",
+                                    MaterialFamily = Material3dFamily.Resin,
+                                    TypeOfMaterial = new Material3dType() { Family = Material3dFamily.Resin, Material = "TOUGH" },
+                                    PackageSize = 1,
+                                    Unit = Unit.Liters,
+                                    UnitPrice = 65,
+                                    Manufacturer = new Manufacturer()
+                                    {
+                                        Name = "Anycubic",
+                                    }
+                                },
+                                PercentageValue = 1,
+                            }
+                        ],
+                        Printer = printerDLP,
+                    },
+                    new Print3dInfo()
+                    {
+                        Name = "My first resin print job",
+                        File = new File3d()
+                        {
+                            FileName = "Superman.dlp",
+                            PrintTime = 1.42,
+                            Volume = 35.4536,
+                            Quantity = 3,
+                        },
+                        MaterialUsages = [
+                            new Material3dUsage()
+                            {
+                                Material = new Material3d()
+                                {
+                                    Name = "Anycubic Tough Resin",
+                                    Density = 1.11,
+                                    ColorCode = "#000000",
+                                    MaterialFamily = Material3dFamily.Resin,
+                                    TypeOfMaterial = new Material3dType() { Family = Material3dFamily.Resin, Material = "TOUGH" },
+                                    PackageSize = 1,
+                                    Unit = Unit.Liters,
+                                    UnitPrice = 65,
+                                    Manufacturer = new Manufacturer()
+                                    {
+                                        Name = "Anycubic",
+                                    }
+                                },
+                                PercentageValue = 1,
+                            }
+                        ],
+                        Printer = printerDLP,
+                    }
+                ],
+                WorkstepUsages = [
+                    new WorkstepUsage()
+                    {
+                        Workstep = new Workstep()
+                        {
+                            Name = "Cleanup",
+                            CalculationType = CalculationType.PerPiece,
+                            Category = new WorkstepCategory() { Name = "Post-Processing" },
+                            Price = 0.5,
+                            Note = "Contains the removal of supports and general cleanup",
+                            Type = WorkstepType.Post,
+                        },
+                        UsageParameter = new WorkstepUsageParameter()
+                        {
+                            ParameterType = WorkstepUsageParameterType.Quantity,
+                            Value = 1,
+                        }
+                    },
+                    new WorkstepUsage()
+                    {
+                        Workstep = new Workstep()
+                        {
+                            Name = "Packaging",
+                            CalculationType = CalculationType.PerJob,
+                            Category = new WorkstepCategory() { Name = "Post-Processing" },
+                            Price = 1,
+                            Note = "Contains the packaging of the prints",
+                            Type = WorkstepType.Post,
+                        },
+                        UsageParameter = new WorkstepUsageParameter()
+                        {
+                            ParameterType = WorkstepUsageParameterType.Quantity,
+                            Value = 1,
+                        }
+                    }
+                    ],
+                ApplyEnergyCost = true,
+                PowerLevel = 75,
+                EnergyCostsPerkWh = 0.4,
+                AdditionalItems = [
+                    new Item3dUsage()
+                    {
+                        Item = new Item3d()
+                        {
+
+                            Name = "Nuts M3",
+                            PackageSize = 100,
+                            PackagePrice = 9.99d,
+                            Manufacturer = new Manufacturer()
+                            {
+                                Name = "Würth",
+                                DebitorNumber = "DE26265126",
+                                Website = "https://www.wuerth.de/",
+                            },
+                            SKU = "2302423-1223"
+                        },
+                        Quantity = 2,
+                    },
+                    new Item3dUsage()
+                    {
+                        Item = new Item3d()
+                        {
+                            Name = "Screws M3 20mm",
+                            PackageSize = 50,
+                            PackagePrice = 14.99d,
+                            Manufacturer = new Manufacturer()
+                            {
+                                Name = "Würth",
+                                DebitorNumber = "DE26265126",
+                                Website = "https://www.wuerth.de/",
+                            },
+                            SKU = "2302423-6413"
+                        },
+                        Quantity = 2,
+                    }
+                    ],
+                FailRate = 5,
+                State = CalculationState.Draft,
+                ApplyProcedureSpecificAdditions = true,
+            };
+
+            List<CalculationProcedureParameter> parameters = [];
+            List<CalculationProcedureParameterAddition> additionalInfo = [];
+
+            if (ApplyResinGlovesCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                        new CalculationProcedureParameterAddition("amount", 100),
+                        new CalculationProcedureParameterAddition("price", 25),
+                        new CalculationProcedureParameterAddition("perjob", 2),
+                    ];
+
+                    parameters =
+                    [
+                        new CalculationProcedureParameter()
+                        {
+                            Type = ProcedureParameter.GloveCosts,
+                            Value = 2d * (25d / 100d),
+                            Additions = additionalInfo,
+                        }
+                    ];
+                    calculation.ProcedureAttributes.Add(
+                        new CalculationProcedureAttribute()
+                        {
+                            Attribute = ProcedureAttribute.GlovesCosts,
+                            Family = Material3dFamily.Resin,
+                            Parameters = parameters,
+                            Level = CalculationLevel.Printer,
+                            PerFile = false,
+                            PerPiece = false,
+                        });
+                }
+            }
+            if (ApplyResinWashingCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                        new CalculationProcedureParameterAddition("amount", 5),
+                        new CalculationProcedureParameterAddition("price", 50),
+                        new CalculationProcedureParameterAddition("perjob", 0.1d),
+                    ];
+
+                    parameters =
+                    [
+                        new CalculationProcedureParameter()
+                        {
+                            Type = ProcedureParameter.WashingCosts,
+                            Value = 0.1d * (50d / 5d),
+                            Additions = additionalInfo,
+                        }
+                    ];
+                    calculation.ProcedureAttributes.Add(
+                        new CalculationProcedureAttribute()
+                        {
+                            Attribute = ProcedureAttribute.WashingCosts,
+                            Family = Material3dFamily.Resin,
+                            Parameters = parameters,
+                            Level = CalculationLevel.Printer,
+                            PerPiece = true,
+                            PerFile = true,
+                        });
+                }
+            }
+            if (ApplyResinFilterCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                        new CalculationProcedureParameterAddition("amount", 50),
+                        new CalculationProcedureParameterAddition("price", 25),
+                        new CalculationProcedureParameterAddition("perjob", 1),
+                    ];
+
+                    parameters =
+                    [
+                        new CalculationProcedureParameter()
+                        {
+                            Type = ProcedureParameter.FilterCosts,
+                            Value = 1d * (25d / 50d),
+                            Additions = additionalInfo,
+                        }
+                    ];
+                    calculation.ProcedureAttributes.Add(
+                        new CalculationProcedureAttribute()
+                        {
+                            Attribute = ProcedureAttribute.FilterCosts,
+                            Family = Material3dFamily.Resin,
+                            Parameters = parameters,
+                            Level = CalculationLevel.Printer,
+                            PerFile = true,
+                            PerPiece = false,
+                        });
+                }
+            }
+            if (ApplyResinTankWearCosts)
+            {
+                if (true)
+                {
+                    // Needed if the calculation is reloaded later
+                    additionalInfo =
+                    [
+                            new CalculationProcedureParameterAddition("replacementcosts", 120),
+                            new CalculationProcedureParameterAddition("wearfactor", 0.01d)
+                    ];
+                    parameters =
+                    [
+                        new CalculationProcedureParameter()
+                        {
+                            Type = ProcedureParameter.ResinTankWearCosts,
+                            Value = 120d  * 0.01d,
+                            Additions = additionalInfo,
+
+                        }
+                    ];
+                    calculation.ProcedureAttributes.Add(
+                        new CalculationProcedureAttribute()
+                        {
+                            Attribute = ProcedureAttribute.ResinTankWear,
+                            Family = Material3dFamily.Resin,
+                            Parameters = parameters,
+                            Level = CalculationLevel.Printer,
+                            PerPiece = false,
+                            PerFile = true,
+                        });
+                }
+            }
         }
 
-        private Calculation3d _calculation;
+        [Test]
+        public void TestProcedureSpecificAddition()
+        {
+            try
+            {
+                Assert.That(calculation is not null);
+                Assert.That(calculation?.ProcedureAttributes?.Count > 0);
+                calculation.ApplyProcedureSpecificAdditions = false;
+                calculation.CalculateCosts();
+                var total = calculation.TotalCosts;
+
+                calculation.ApplyProcedureSpecificAdditions = true;
+                calculation.CalculateCosts();
+                var total2 = calculation.TotalCosts;
+                Assert.That(total < total2);
+
+                /*
+                 * GloveCosts: Should be available only once per machine and print job
+                 * FilterCosts: Should be available once per print job info
+                 * WashingCosts: Are per print job info and file quantity
+                 */
+
+                var gloveCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "GloveCosts")?.ToList();
+                Assert.That(gloveCosts?.Count == calculation.AvailablePrinters.Where(printer => printer.MaterialType == Material3dFamily.Resin).Count());
+                Assert.That(gloveCosts?.Sum(c => c.Value) == 0.5d);
+
+                int fileCount = calculation.PrintInfos.Where(pi => pi.Printer.MaterialType == Material3dFamily.Resin).Count();
+
+                var filterCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "FilterCosts")?.ToList();
+                Assert.That(filterCosts?.Count == fileCount);
+                Assert.That(filterCosts?.Sum(c => c.Value) == 1d);
+
+                var washingCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "WashingCosts")?.ToList();
+                Assert.That(washingCosts?.Count == fileCount);
+                foreach (var washCost in washingCosts)
+                {
+                    File3d f = calculation.PrintInfos.FirstOrDefault(pi => pi.File.Id == washCost.FileId).File;
+                    Assert.That(washCost.Value / f.Quantity == 1d);
+                }
+
+                var tankWearCosts = calculation.OverallPrinterCosts.Where(c => c.Attribute == "ResinTankWearCosts")?.ToList();
+                Assert.That(tankWearCosts?.Count == fileCount);
+                Assert.That(tankWearCosts?.Sum(c => c.Value) == 2.4d);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message);
+            }
+        }
+
+        private Calculation3d calculationObsolete;
         [Test]
         public void TestCalculation()
         {
@@ -90,20 +539,20 @@ namespace AndreasReitberger.NUnitTest
                     LinkedToFile = false,
                 };
 
-                _calculation = new();
+                calculationObsolete = new();
                 // Add data
-                _calculation.AdditionalItems.Add(usage);
-                _calculation.Files.Add(file);
-                _calculation.Files.Add(file2);
-                _calculation.Printers.Add(printer);
-                _calculation.Materials.Add(material);
-                _calculation.Rates.Add(new()
+                calculationObsolete.AdditionalItems.Add(usage);
+                calculationObsolete.Files.Add(file);
+                calculationObsolete.Files.Add(file2);
+                calculationObsolete.Printers.Add(printer);
+                calculationObsolete.Materials.Add(material);
+                calculationObsolete.Rates.Add(new()
                 {
                     Type = CalculationAttributeType.Tax,
                     IsPercentageValue = true,
                     Value = 19,
                 });
-                _calculation.Rates.Add(new()
+                calculationObsolete.Rates.Add(new()
                 {
                     Type = CalculationAttributeType.Margin,
                     IsPercentageValue = true,
@@ -111,29 +560,29 @@ namespace AndreasReitberger.NUnitTest
                 });
 
                 // Add information
-                _calculation.FailRate = 25;
-                _calculation.EnergyCostsPerkWh = 0.30;
-                _calculation.ApplyEnergyCost = true;
+                calculationObsolete.FailRate = 25;
+                calculationObsolete.EnergyCostsPerkWh = 0.30;
+                calculationObsolete.ApplyEnergyCost = true;
                 // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-                _calculation.PowerLevel = 75;
+                calculationObsolete.PowerLevel = 75;
 
-                _calculation.CalculateCosts();
-                double totalCosts = _calculation.TotalCosts;
-                Assert.That(_calculation.IsCalculated);
+                calculationObsolete.CalculateCosts();
+                double totalCosts = calculationObsolete.TotalCosts;
+                Assert.That(calculationObsolete.IsCalculated);
 
                 List<double> costsCalc = new()
                 {
-                    _calculation.MachineCosts,
-                    _calculation.MaterialCosts,
-                    _calculation.CalculatedMargin,
-                    _calculation.CalculatedTax,
-                    _calculation.ItemsCosts,
+                    calculationObsolete.MachineCosts,
+                    calculationObsolete.MaterialCosts,
+                    calculationObsolete.CalculatedMargin,
+                    calculationObsolete.CalculatedTax,
+                    calculationObsolete.ItemsCosts,
                 };
                 double summedCalc = costsCalc.Sum();
-                Assert.That(Math.Round(summedCalc, 2) == Math.Round(_calculation.TotalCosts, 2));
+                Assert.That(Math.Round(summedCalc, 2) == Math.Round(calculationObsolete.TotalCosts, 2));
 
 
-                Calculation3d _calculation2 = _calculation?.Clone() as Calculation3d;
+                Calculation3d _calculation2 = calculationObsolete?.Clone() as Calculation3d;
                 _calculation2.CalculateCosts();
                 Assert.That(_calculation2.IsCalculated);
                 Assert.That(totalCosts == _calculation2.TotalCosts);
@@ -211,21 +660,21 @@ namespace AndreasReitberger.NUnitTest
                     MultiplyPrintTimeWithQuantity = false
                 };
 
-                _calculation = new Calculation3d();
+                calculationObsolete = new Calculation3d();
                 // Add data
-                _calculation.Files.Add(file);
-                _calculation.Files.Add(file2);
-                _calculation.Printers.Add(printer);
-                _calculation.Materials.Add(material);
+                calculationObsolete.Files.Add(file);
+                calculationObsolete.Files.Add(file2);
+                calculationObsolete.Printers.Add(printer);
+                calculationObsolete.Materials.Add(material);
 
                 // Add information
-                _calculation.FailRate = 25;
-                _calculation.EnergyCostsPerkWh = 0.30;
-                _calculation.ApplyEnergyCost = true;
+                calculationObsolete.FailRate = 25;
+                calculationObsolete.EnergyCostsPerkWh = 0.30;
+                calculationObsolete.ApplyEnergyCost = true;
                 // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-                _calculation.PowerLevel = 75;
+                calculationObsolete.PowerLevel = 75;
 
-                _calculation.CalculateCosts();
+                calculationObsolete.CalculateCosts();
 #if NETFRAMEWORK
                 Calculator3dExporter.Save(_calculation, @"mycalc.3dcx");
                 Calculator3dExporter.Load(@"mycalc.3dcx", out Calculation3d calculation);
@@ -305,21 +754,21 @@ namespace AndreasReitberger.NUnitTest
                     MultiplyPrintTimeWithQuantity = false
                 };
 
-                _calculation = new Calculation3d();
+                calculationObsolete = new Calculation3d();
                 // Add data
-                _calculation.Files.Add(file);
-                _calculation.Files.Add(file2);
-                _calculation.Printers.Add(printer);
-                _calculation.Materials.Add(material);
+                calculationObsolete.Files.Add(file);
+                calculationObsolete.Files.Add(file2);
+                calculationObsolete.Printers.Add(printer);
+                calculationObsolete.Materials.Add(material);
 
                 // Add information
-                _calculation.FailRate = 25;
-                _calculation.EnergyCostsPerkWh = 0.30;
-                _calculation.ApplyEnergyCost = true;
+                calculationObsolete.FailRate = 25;
+                calculationObsolete.EnergyCostsPerkWh = 0.30;
+                calculationObsolete.ApplyEnergyCost = true;
                 // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-                _calculation.PowerLevel = 75;
+                calculationObsolete.PowerLevel = 75;
 
-                _calculation.ApplyProcedureSpecificAdditions = true;
+                calculationObsolete.ApplyProcedureSpecificAdditions = true;
                 // Needed if the calculation is reloaded later
                 List<CalculationProcedureParameterAddition> additionalInfo = new()
                 {
@@ -338,7 +787,7 @@ namespace AndreasReitberger.NUnitTest
                     }
                 };
 
-                _calculation.ProcedureAttributes.Add(
+                calculationObsolete.ProcedureAttributes.Add(
                     new CalculationProcedureAttribute()
                     {
                         Attribute = ProcedureAttribute.NozzleWear,
@@ -348,23 +797,23 @@ namespace AndreasReitberger.NUnitTest
                     }
                 );
 
-                _calculation.CalculateCosts();
+                calculationObsolete.CalculateCosts();
 
-                CalculationAttribute wearCostAttribute = _calculation.OverallPrinterCosts.FirstOrDefault(item =>
+                CalculationAttribute wearCostAttribute = calculationObsolete.OverallPrinterCosts.FirstOrDefault(item =>
                 item.Type == CalculationAttributeType.ProcedureSpecificAddition &&
                 item.Attribute == "NozzleWearCosts"
                 );
                 Assert.That(wearCostAttribute is not null);
 
                 // Updat calculation
-                _calculation.Printer = null;
-                _calculation.Printers = new List<Printer3d>
+                calculationObsolete.Printer = null;
+                calculationObsolete.Printers = new List<Printer3d>
                 {
                     printerSla
                 };
 
-                _calculation.CalculateCosts();
-                wearCostAttribute = _calculation.OverallPrinterCosts.FirstOrDefault(item =>
+                calculationObsolete.CalculateCosts();
+                wearCostAttribute = calculationObsolete.OverallPrinterCosts.FirstOrDefault(item =>
                 item.Type == CalculationAttributeType.ProcedureSpecificAddition &&
                 item.Attribute == "NozzleWearCosts"
                 );
@@ -474,16 +923,16 @@ namespace AndreasReitberger.NUnitTest
                 LinkedToFile = false,
             };
 
-            _calculation = new Calculation3d();
+            calculationObsolete = new Calculation3d();
             // Add data
-            _calculation.AdditionalItems.Add(usage);
-            _calculation.Files.Add(file);
-            _calculation.Files.Add(file2);
-            _calculation.Printers.Add(printer);
-            _calculation.Printers.Add(printer2);
-            _calculation.Materials.Add(material);
-            _calculation.Materials.Add(material2);
-            _calculation.ProcedureAdditions.Add(new ProcedureAddition()
+            calculationObsolete.AdditionalItems.Add(usage);
+            calculationObsolete.Files.Add(file);
+            calculationObsolete.Files.Add(file2);
+            calculationObsolete.Printers.Add(printer);
+            calculationObsolete.Printers.Add(printer2);
+            calculationObsolete.Materials.Add(material);
+            calculationObsolete.Materials.Add(material2);
+            calculationObsolete.ProcedureAdditions.Add(new ProcedureAddition()
             {
                 Name = "Resin Tank Replacement",
                 Description = "Take the costs for the resin tank replacement into account?",
@@ -502,7 +951,7 @@ namespace AndreasReitberger.NUnitTest
                     }
                 }
             });
-            _calculation.ProcedureAdditions.Add(new ProcedureAddition()
+            calculationObsolete.ProcedureAdditions.Add(new ProcedureAddition()
             {
                 Name = "Gloves",
                 Description = "Take the costs for the gloves?",
@@ -523,14 +972,14 @@ namespace AndreasReitberger.NUnitTest
             });
 
             // Add information
-            _calculation.FailRate = 25;
-            _calculation.EnergyCostsPerkWh = 0.30;
-            _calculation.ApplyEnergyCost = true;
+            calculationObsolete.FailRate = 25;
+            calculationObsolete.EnergyCostsPerkWh = 0.30;
+            calculationObsolete.ApplyEnergyCost = true;
             // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-            _calculation.PowerLevel = 75;
+            calculationObsolete.PowerLevel = 75;
 
-            _calculation.CalculateCosts();
-            return _calculation;
+            calculationObsolete.CalculateCosts();
+            return calculationObsolete;
         }
 
         [Test]
@@ -612,35 +1061,35 @@ namespace AndreasReitberger.NUnitTest
                     MultiplyPrintTimeWithQuantity = true
                 };
 
-                _calculation = new Calculation3d();
+                calculationObsolete = new Calculation3d();
                 // Add data
-                _calculation.Files.Add(file);
-                _calculation.Files.Add(file2);
-                _calculation.Files.Add(file3);
-                _calculation.Printers.Add(printer);
-                _calculation.Materials.Add(material);
-                _calculation.Materials.Add(material2);
+                calculationObsolete.Files.Add(file);
+                calculationObsolete.Files.Add(file2);
+                calculationObsolete.Files.Add(file3);
+                calculationObsolete.Printers.Add(printer);
+                calculationObsolete.Materials.Add(material);
+                calculationObsolete.Materials.Add(material2);
 
                 // Add information
-                _calculation.FailRate = 25;
-                _calculation.EnergyCostsPerkWh = 0.30;
-                _calculation.ApplyEnergyCost = true;
+                calculationObsolete.FailRate = 25;
+                calculationObsolete.EnergyCostsPerkWh = 0.30;
+                calculationObsolete.ApplyEnergyCost = true;
                 // Uses 75% of the max. power consumption set in the printer model (210 Watt)
-                _calculation.PowerLevel = 75;
+                calculationObsolete.PowerLevel = 75;
 
-                _calculation.CalculateCosts();
+                calculationObsolete.CalculateCosts();
 
-                double total = _calculation.GetTotalCosts();
+                double total = calculationObsolete.GetTotalCosts();
 
-                var materialCosts = PrintCalculator3d.GetMaterialCosts(_calculation);
-                var machineCosts = PrintCalculator3d.GetMachineCosts(_calculation);
+                var materialCosts = PrintCalculator3d.GetMaterialCosts(calculationObsolete);
+                var machineCosts = PrintCalculator3d.GetMachineCosts(calculationObsolete);
 
-                _calculation.DifferFileCosts = true;
-                _calculation.CalculateCosts();
+                calculationObsolete.DifferFileCosts = true;
+                calculationObsolete.CalculateCosts();
 
-                double totalDiffer = _calculation.GetTotalCosts();
+                double totalDiffer = calculationObsolete.GetTotalCosts();
 
-                Assert.That(_calculation.IsCalculated);
+                Assert.That(calculationObsolete.IsCalculated);
                 Assert.That(total == totalDiffer);
             }
             catch (Exception exc)

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
@@ -978,7 +978,7 @@ namespace AndreasReitberger.NUnitTest
                     Print3dInfo info = new()
                     {
                         File = file,
-                        MaterialUsages = [new() { Material = material, Percentage = 1 }],
+                        MaterialUsages = [new() { Material = material, PercentageValue = 1 }],
                         Printer = printer,
                         Items = [usage],
                     };
@@ -986,7 +986,7 @@ namespace AndreasReitberger.NUnitTest
                     {
                         File = file2,
                         // Multi-Material for one file
-                        MaterialUsages = [new() { Material = material, Percentage = 0.5 }, new() { Material = material2, Percentage = 0.5 }],
+                        MaterialUsages = [new() { Material = material, PercentageValue = 0.5 }, new() { Material = material2, PercentageValue = 0.5 }],
                         Printer = printer2,
                     };
 

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
@@ -948,6 +948,7 @@ namespace AndreasReitberger.NUnitTest
                         Price = 50,
                         WearFactor = 1000,
                         QuantityInPackage = 1,
+
                     }
                 }
             });

--- a/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3d.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3d.Extensions.cs
@@ -262,15 +262,19 @@ namespace AndreasReitberger.Print3d.Realm
                             {
                                 foreach (CalculationProcedureParameter parameter in attribute.Parameters)
                                 {
-                                    OverallPrinterCosts?.Add(new CalculationAttribute()
+                                    if (attribute.PerFile || (OverallPrinterCosts?
+                                            .FirstOrDefault(attr => attr.Attribute == parameter.Type.ToString() && attr.LinkedId == printer.Id) is null))
                                     {
-                                        LinkedId = printer.Id,
-                                        Attribute = parameter.Type.ToString(),
-                                        Type = CalculationAttributeType.ProcedureSpecificAddition,
-                                        Value = parameter.Value,
-                                        FileId = file.Id,
-                                        FileName = file.FileName,
-                                    });
+                                        OverallPrinterCosts?.Add(new CalculationAttribute()
+                                        {
+                                            LinkedId = printer.Id,
+                                            Attribute = parameter.Type.ToString(),
+                                            Type = CalculationAttributeType.ProcedureSpecificAddition,
+                                            Value = attribute.PerPiece ? parameter.Value * file.Quantity : parameter.Value,
+                                            FileId = file.Id,
+                                            FileName = file.FileName,
+                                        });
+                                    }
                                 }
                             }
 

--- a/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3dEnhanced.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3dEnhanced.Extensions.cs
@@ -20,7 +20,6 @@ namespace AndreasReitberger.Print3d.Realm
             OverallMaterialCosts?.Clear();
             OverallPrinterCosts?.Clear();
             Costs?.Clear();
-            CombineMaterialCosts = false;
 
             int quantity = PrintInfos.Select(f => f.File).Select(file => file.Quantity).ToList().Sum();
             // Add the handling fee based on the file quantity
@@ -256,15 +255,19 @@ namespace AndreasReitberger.Print3d.Realm
                             {
                                 foreach (CalculationProcedureParameter parameter in attribute.Parameters)
                                 {
-                                    OverallPrinterCosts?.Add(new CalculationAttribute()
+                                    if (attribute.PerFile || (OverallPrinterCosts?
+                                            .FirstOrDefault(attr => attr.Attribute == parameter.Type.ToString() && attr.LinkedId == printer.Id) is null))
                                     {
-                                        LinkedId = printer.Id,
-                                        Attribute = parameter.Type.ToString(),
-                                        Type = CalculationAttributeType.ProcedureSpecificAddition,
-                                        Value = parameter.Value * file.Quantity,
-                                        FileId = file.Id,
-                                        FileName = file.FileName,
-                                    });
+                                        OverallPrinterCosts?.Add(new CalculationAttribute()
+                                        {
+                                            LinkedId = printer.Id,
+                                            Attribute = parameter.Type.ToString(),
+                                            Type = CalculationAttributeType.ProcedureSpecificAddition,
+                                            Value = attribute.PerPiece ? parameter.Value * file.Quantity : parameter.Value,
+                                            FileId = file.Id,
+                                            FileName = file.FileName,
+                                        });
+                                    }
                                 }
                             }
 

--- a/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3dEnhanced.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/Calculation3dEnhanced.Extensions.cs
@@ -68,7 +68,7 @@ namespace AndreasReitberger.Print3d.Realm
                             FileName = file.FileName,
                         });
                     }
-                    double percentageUsage = info.MaterialUsages?.Select(mu => mu.Percentage).Sum() ?? 1;
+                    double percentageUsage = info.MaterialUsages?.Select(mu => mu.PercentageValue).Sum() ?? 1;
                     if (percentageUsage > 1 || percentageUsage <= 0)
                         throw new ArgumentOutOfRangeException($"The overall percentage of the material usage is greater than 1 (=100%): {percentageUsage}");
                     foreach (Material3dUsage materialUsageInfo in info.MaterialUsages.Cast<Material3dUsage>())
@@ -88,7 +88,7 @@ namespace AndreasReitberger.Print3d.Realm
                                 _weight = file.Weight.Weight * Convert.ToDouble(UnitFactor.GetUnitFactor(file.Weight.Unit));
                             }
                             // Needed material in g
-                            double _material = _weight * file.Quantity * materialUsageInfo.Percentage;
+                            double _material = _weight * file.Quantity * materialUsageInfo.PercentageValue;
                             MaterialUsage?.Add(new CalculationAttribute()
                             {
                                 Attribute = material.Name,

--- a/source/3dPrintCalculatorLibrary.Realm/Models/CalculationAdditions/CalculationProcedureAttribute.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/CalculationAdditions/CalculationProcedureAttribute.cs
@@ -36,6 +36,9 @@ namespace AndreasReitberger.Print3d.Realm.CalculationAdditions
             set { LevelId = (int)value; }
         }
         public int LevelId { get; set; } = (int)CalculationLevel.Printer;
+
+        public bool PerFile { get; set; } = false;
+        public bool PerPiece { get; set; } = false;
         #endregion
 
         #region Constructor

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3d.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3d.Extensions.cs
@@ -258,15 +258,19 @@ namespace AndreasReitberger.Print3d.SQLite
                             {
                                 foreach (CalculationProcedureParameter parameter in attribute.Parameters)
                                 {
-                                    OverallPrinterCosts?.Add(new CalculationAttribute()
+                                    if (attribute.PerFile || (OverallPrinterCosts?
+                                            .FirstOrDefault(attr => attr.Attribute == parameter.Type.ToString() && attr.LinkedId == printer.Id) is null))
                                     {
-                                        LinkedId = printer.Id,
-                                        Attribute = parameter.Type.ToString(),
-                                        Type = CalculationAttributeType.ProcedureSpecificAddition,
-                                        Value = parameter.Value * file.Quantity,
-                                        FileId = file.Id,
-                                        FileName = file.FileName,
-                                    });
+                                        OverallPrinterCosts?.Add(new CalculationAttribute()
+                                        {
+                                            LinkedId = printer.Id,
+                                            Attribute = parameter.Type.ToString(),
+                                            Type = CalculationAttributeType.ProcedureSpecificAddition,
+                                            Value = attribute.PerPiece ? parameter.Value * file.Quantity : parameter.Value,
+                                            FileId = file.Id,
+                                            FileName = file.FileName,
+                                        });
+                                    }
                                 }
                             }
 

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3dEnhanced.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/Calculation3dEnhanced.Extensions.cs
@@ -16,7 +16,6 @@ namespace AndreasReitberger.Print3d.SQLite
             OverallMaterialCosts?.Clear();
             OverallPrinterCosts?.Clear();
             Costs?.Clear();
-            CombineMaterialCosts = false;
 
             int quantity = PrintInfos.Select(f => f.File).Select(file => file.Quantity).ToList().Sum();
             // Add the handling fee based on the file quantity
@@ -252,15 +251,19 @@ namespace AndreasReitberger.Print3d.SQLite
                             {
                                 foreach (CalculationProcedureParameter parameter in attribute.Parameters)
                                 {
-                                    OverallPrinterCosts?.Add(new CalculationAttribute()
+                                    if (attribute.PerFile || (OverallPrinterCosts?
+                                            .FirstOrDefault(attr => attr.Attribute == parameter.Type.ToString() && attr.LinkedId == printer.Id) is null))
                                     {
-                                        LinkedId = printer.Id,
-                                        Attribute = parameter.Type.ToString(),
-                                        Type = CalculationAttributeType.ProcedureSpecificAddition,
-                                        Value = parameter.Value * file.Quantity,
-                                        FileId = file.Id,
-                                        FileName = file.FileName,
-                                    });
+                                        OverallPrinterCosts?.Add(new CalculationAttribute()
+                                        {
+                                            LinkedId = printer.Id,
+                                            Attribute = parameter.Type.ToString(),
+                                            Type = CalculationAttributeType.ProcedureSpecificAddition,
+                                            Value = attribute.PerPiece ? parameter.Value * file.Quantity : parameter.Value,
+                                            FileId = file.Id,
+                                            FileName = file.FileName,
+                                        });
+                                    }
                                 }
                             }
 

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/CalculationAdditions/CalculationProcedureAttribute.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/CalculationAdditions/CalculationProcedureAttribute.cs
@@ -31,10 +31,16 @@ namespace AndreasReitberger.Print3d.SQLite.CalculationAdditions
 
         [ObservableProperty]
         [property: OneToMany(CascadeOperations = CascadeOperation.All)]
-        List<CalculationProcedureParameter> parameters = new();
+        List<CalculationProcedureParameter> parameters = [];
 
         [ObservableProperty]
         CalculationLevel level = CalculationLevel.Printer;
+
+        [ObservableProperty]
+        bool perFile = false;
+
+        [ObservableProperty]
+        bool perPiece = false;
         #endregion
 
         #region Constructor

--- a/source/3dPrintCalculatorLibrary/Interfaces/ICalculationProcedureAttribute.cs
+++ b/source/3dPrintCalculatorLibrary/Interfaces/ICalculationProcedureAttribute.cs
@@ -11,6 +11,8 @@ namespace AndreasReitberger.Print3d.Interfaces
         public Material3dFamily Family { get; set; }
         public ProcedureAttribute Attribute { get; set; }
         public CalculationLevel Level { get; set; }
+        public bool PerPiece { get; set; }
+        public bool PerFile { get; set; }
         #endregion
 
         #region List

--- a/source/3dPrintCalculatorLibrary/Models/Calculation3d.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Calculation3d.Extensions.cs
@@ -262,15 +262,19 @@ namespace AndreasReitberger.Print3d.Models
                             {
                                 foreach (CalculationProcedureParameter parameter in attribute.Parameters)
                                 {
-                                    OverallPrinterCosts?.Add(new CalculationAttribute()
+                                    if (attribute.PerFile || (OverallPrinterCosts?
+                                            .FirstOrDefault(attr => attr.Attribute == parameter.Type.ToString() && attr.LinkedId == printer.Id) is null))
                                     {
-                                        LinkedId = printer.Id,
-                                        Attribute = parameter.Type.ToString(),
-                                        Type = CalculationAttributeType.ProcedureSpecificAddition,
-                                        Value = parameter.Value,
-                                        FileId = file.Id,
-                                        FileName = file.FileName,
-                                    });
+                                        OverallPrinterCosts?.Add(new CalculationAttribute()
+                                        {
+                                            LinkedId = printer.Id,
+                                            Attribute = parameter.Type.ToString(),
+                                            Type = CalculationAttributeType.ProcedureSpecificAddition,
+                                            Value = attribute.PerPiece ? parameter.Value * file.Quantity : parameter.Value,
+                                            FileId = file.Id,
+                                            FileName = file.FileName,
+                                        });
+                                    }
                                 }
                             }
 

--- a/source/3dPrintCalculatorLibrary/Models/Calculation3dEnhanced.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Calculation3dEnhanced.Extensions.cs
@@ -20,7 +20,6 @@ namespace AndreasReitberger.Print3d.Models
             OverallMaterialCosts?.Clear();
             OverallPrinterCosts?.Clear();
             Costs?.Clear();
-            CombineMaterialCosts = false;
 
             int quantity = PrintInfos.Select(f => f.File).Select(file => file.Quantity).ToList().Sum();
             // Add the handling fee based on the file quantity
@@ -256,15 +255,19 @@ namespace AndreasReitberger.Print3d.Models
                             {
                                 foreach (CalculationProcedureParameter parameter in attribute.Parameters)
                                 {
-                                    OverallPrinterCosts?.Add(new CalculationAttribute()
+                                    if (attribute.PerFile || (OverallPrinterCosts?
+                                            .FirstOrDefault(attr => attr.Attribute == parameter.Type.ToString() && attr.LinkedId == printer.Id) is null))
                                     {
-                                        LinkedId = printer.Id,
-                                        Attribute = parameter.Type.ToString(),
-                                        Type = CalculationAttributeType.ProcedureSpecificAddition,
-                                        Value = parameter.Value * file.Quantity,
-                                        FileId = file.Id,
-                                        FileName = file.FileName,
-                                    });
+                                        OverallPrinterCosts?.Add(new CalculationAttribute()
+                                        {
+                                            LinkedId = printer.Id,
+                                            Attribute = parameter.Type.ToString(),
+                                            Type = CalculationAttributeType.ProcedureSpecificAddition,
+                                            Value = attribute.PerPiece ? parameter.Value * file.Quantity : parameter.Value,
+                                            FileId = file.Id,
+                                            FileName = file.FileName,
+                                        });
+                                    }
                                 }
                             }
 

--- a/source/3dPrintCalculatorLibrary/Models/Calculation3dEnhanced.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary/Models/Calculation3dEnhanced.Extensions.cs
@@ -68,7 +68,7 @@ namespace AndreasReitberger.Print3d.Models
                             FileName = file.FileName,
                         });
                     }
-                    double percentageUsage = info.MaterialUsages?.Select(mu => mu.Percentage).Sum() ?? 1;
+                    double percentageUsage = info.MaterialUsages?.Select(mu => mu.PercentageValue).Sum() ?? 1;
                     if (percentageUsage > 1 || percentageUsage <= 0)
                         throw new ArgumentOutOfRangeException($"The overall percentage of the material usage is greater than 1 (=100%): {percentageUsage}");
                     foreach (Material3dUsage materialUsageInfo in info.MaterialUsages)
@@ -88,7 +88,7 @@ namespace AndreasReitberger.Print3d.Models
                                 _weight = file.Weight.Weight * Convert.ToDouble(UnitFactor.GetUnitFactor(file.Weight.Unit));
                             }
                             // Needed material in g
-                            double _material = _weight * file.Quantity * materialUsageInfo.Percentage;
+                            double _material = _weight * file.Quantity * materialUsageInfo.PercentageValue;
                             MaterialUsage?.Add(new CalculationAttribute()
                             {
                                 Attribute = material.Name,

--- a/source/3dPrintCalculatorLibrary/Models/CalculationAdditions/CalculationProcedureAttribute.cs
+++ b/source/3dPrintCalculatorLibrary/Models/CalculationAdditions/CalculationProcedureAttribute.cs
@@ -26,6 +26,12 @@ namespace AndreasReitberger.Print3d.Models.CalculationAdditions
 
         [ObservableProperty]
         CalculationLevel level = CalculationLevel.Printer;
+
+        [ObservableProperty]
+        bool perFile = false;
+
+        [ObservableProperty]
+        bool perPiece = false;
         #endregion
 
         #region Constructor


### PR DESCRIPTION
This commit fixes., that the `Calculation3d` multiplies the procude specific additions with the quantity of the files and the `Calculation3dEnhanced`, which does not take the cots in account at all.

- [x] Fix `Calculation3d`
- [x] Fix `Calculation3dEnhanced` 
- [x] Fix and update tests to verify the changes
- [x] Verify functionality in application

Fixed #113