### PR TITLE
Fixed `Margin` calculation if `HandlingFee` is applied

### DIFF
--- a/common.props
+++ b/common.props
@@ -1,7 +1,7 @@
 
 <Project>
     <PropertyGroup>
-        <Version>1.2.4-preview1</Version>
+        <Version>2.0.0-preview1</Version>
         <!--<PackageIcon>logo_128.png</PackageIcon>-->
         <NeutralLanguage>en</NeutralLanguage>
 		<PackageProjectUrl>https://github.com/AndreasReitberger/3dPrintCostCalculatorSharp</PackageProjectUrl>

--- a/source/3dPrintCalculatorLibrary.Core/Enums/CalculationAttributeTarget.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Enums/CalculationAttributeTarget.cs
@@ -5,5 +5,7 @@
         PrintTime,
         Material,
         Fee,
+        File,
+        Project,
     }
 }

--- a/source/3dPrintCalculatorLibrary.Core/Enums/CalculationAttributeType.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Enums/CalculationAttributeType.cs
@@ -13,5 +13,6 @@
         FixCost,
         ProcedureSpecificAddition,
         AdditionalItem,
+        HandlingFee,
     }
 }

--- a/source/3dPrintCalculatorLibrary.Core/Interfaces/ICalculationAttribute.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Interfaces/ICalculationAttribute.cs
@@ -11,6 +11,7 @@ namespace AndreasReitberger.Print3d.Core.Interfaces
         public string FileName { get; set; }
         public Guid LinkedId { get; set; }
         public string Attribute { get; set; }
+        public CalculationAttributeTarget Target { get; set; }
         public CalculationAttributeType Type { get; set; }
         public CalculationAttributeItem Item { get; set; }
         public double Value { get; set; }

--- a/source/3dPrintCalculatorLibrary.Core/Models/Calculation3dEnhanced.Extensions.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Models/Calculation3dEnhanced.Extensions.cs
@@ -19,7 +19,7 @@ namespace AndreasReitberger.Print3d.Core
 
             int quantity = PrintInfos.Select(f => f.FileUsage).Select(file => file.Quantity).ToList().Sum();
             // Add the handling fee based on the file quantity
-            ICalculationAttribute? handlingsFee = Rates?.FirstOrDefault(costs => costs.Attribute == "HandlingFee");
+            ICalculationAttribute? handlingsFee = Rates?.FirstOrDefault(costs => costs.Attribute == "HandlingFee" || costs.Type == CalculationAttributeType.HandlingFee);
             ICalculationAttribute? margin = Rates?.FirstOrDefault(costs => costs.Type == CalculationAttributeType.Margin);
             ICalculationAttribute? tax = Rates?.FirstOrDefault(costs => costs.Type == CalculationAttributeType.Tax);
 
@@ -37,6 +37,7 @@ namespace AndreasReitberger.Print3d.Core
                         Value = printTime,
                         Type = CalculationAttributeType.Machine,
                         Item = CalculationAttributeItem.Default,
+                        Target = CalculationAttributeTarget.File,
                         FileId = file.Id,
                         FileName = file.FileName,
                     });
@@ -47,6 +48,7 @@ namespace AndreasReitberger.Print3d.Core
                         {
                             Attribute = "HandlingFee",
                             Type = CalculationAttributeType.FixCost,
+                            Target = CalculationAttributeTarget.File,
                             Value = Convert.ToDouble(handlingsFee?.Value * fileUsage.Quantity),
                             FileId = file.Id,
                             FileName = file.FileName,
@@ -59,6 +61,7 @@ namespace AndreasReitberger.Print3d.Core
                             Attribute = $"{file.FileName}_FailRate",
                             Type = CalculationAttributeType.Machine,
                             Item = CalculationAttributeItem.FailRate,
+                            Target = CalculationAttributeTarget.File,
                             Value = printTime * FailRate / 100,
                             FileId = file.Id,
                             FileName = file.FileName,
@@ -90,6 +93,7 @@ namespace AndreasReitberger.Print3d.Core
                                 Value = _material,
                                 Type = CalculationAttributeType.Material,
                                 Item = CalculationAttributeItem.Default,
+                                Target = CalculationAttributeTarget.File,
                                 FileId = file.Id,
                                 FileName = file.FileName,
                             });
@@ -101,6 +105,7 @@ namespace AndreasReitberger.Print3d.Core
                                     Value = _material * FailRate / 100,
                                     Type = CalculationAttributeType.Material,
                                     Item = CalculationAttributeItem.FailRate,
+                                    Target = CalculationAttributeTarget.File,
                                     FileId = file.Id,
                                     FileName = file.FileName,
                                 });
@@ -154,6 +159,7 @@ namespace AndreasReitberger.Print3d.Core
                                             LinkedId = material.Id,
                                             Attribute = add.Name,
                                             Type = CalculationAttributeType.ProcedureSpecificAddition,
+                                            Target = CalculationAttributeTarget.File,
                                             Value = costs,
                                             FileId = file.Id,
                                             FileName = file.FileName,
@@ -175,6 +181,7 @@ namespace AndreasReitberger.Print3d.Core
                                     // Keep the linking to the currently used material
                                     Attribute = materialUsage.Item == CalculationAttributeItem.FailRate ? $"{material.Name}_FailRate" : material.Name,
                                     Type = CalculationAttributeType.Material,
+                                    Target = CalculationAttributeTarget.File,
                                     Item = materialUsage.Item,
                                     Value = totalCosts,
                                     FileId = materialUsage.FileId,
@@ -192,6 +199,7 @@ namespace AndreasReitberger.Print3d.Core
                                     Attribute = $"{material.Name} (Refreshed)",
                                     Type = CalculationAttributeType.Material,
                                     Item = CalculationAttributeItem.PowderRefresh,
+                                    Target = CalculationAttributeTarget.File,
                                     Value = refreshCosts,
                                     FileId = file.Id,
                                     FileName = file.FileName,
@@ -215,6 +223,7 @@ namespace AndreasReitberger.Print3d.Core
                                         LinkedId = printer.Id,
                                         Attribute = printer.Name,
                                         Type = CalculationAttributeType.Machine,
+                                        Target = CalculationAttributeTarget.File,
                                         Item = pt.Item,
                                         Value = machineHourRate,
                                         FileId = pt.FileId,
@@ -234,6 +243,7 @@ namespace AndreasReitberger.Print3d.Core
                                         LinkedId = printer.Id,
                                         Attribute = printer.Name,
                                         Type = CalculationAttributeType.Energy,
+                                        Target = CalculationAttributeTarget.File,
                                         Item = pt.Item,
                                         Value = totalEnergyCost,
                                         FileId = pt.FileId,
@@ -259,6 +269,7 @@ namespace AndreasReitberger.Print3d.Core
                                             LinkedId = printer.Id,
                                             Attribute = parameter.Type.ToString(),
                                             Type = CalculationAttributeType.ProcedureSpecificAddition,
+                                            Target = CalculationAttributeTarget.File,
                                             Value = attribute.PerPiece ? parameter.Value * fileUsage.Quantity : parameter.Value,
                                             FileId = file.Id,
                                             FileName = file.FileName,
@@ -283,6 +294,7 @@ namespace AndreasReitberger.Print3d.Core
                                         LinkedId = printer.Id,
                                         Attribute = add.Name,
                                         Type = CalculationAttributeType.ProcedureSpecificAddition,
+                                        Target = CalculationAttributeTarget.File,
                                         Value = costs,
                                         FileId = file.Id,
                                         FileName = file.FileName,
@@ -305,6 +317,7 @@ namespace AndreasReitberger.Print3d.Core
                                 LinkedId = ws.Id,
                                 Attribute = ws.Name,
                                 Type = CalculationAttributeType.Workstep,
+                                Target = CalculationAttributeTarget.File,
                                 Value = totalPerPiece,
                                 FileId = file.Id,
                                 FileName = file.FileName,
@@ -326,6 +339,7 @@ namespace AndreasReitberger.Print3d.Core
                                 LinkedId = item.Id,
                                 Attribute = item.Item.Name,
                                 Type = CalculationAttributeType.AdditionalItem,
+                                Target = CalculationAttributeTarget.File,
                                 Value = totalPerPiece,
                                 FileId = file.Id,
                                 FileName = file.FileName,
@@ -346,6 +360,7 @@ namespace AndreasReitberger.Print3d.Core
                                 LinkedId = item.Id,
                                 Attribute = item.Item.Name,
                                 Type = CalculationAttributeType.AdditionalItem,
+                                Target = CalculationAttributeTarget.File,
                                 Value = totalPerPiece,
                                 FileId = file.Id,
                                 FileName = file.FileName,
@@ -359,7 +374,7 @@ namespace AndreasReitberger.Print3d.Core
 
                     if (customAdditionsBeforeMargin?.Count > 0)
                     {
-                        SortedDictionary<int, double> additions = new();
+                        SortedDictionary<int, double> additions = [];
                         foreach (ICustomAddition ca in customAdditionsBeforeMargin)
                         {
                             if (additions.ContainsKey(ca.Order))
@@ -374,6 +389,7 @@ namespace AndreasReitberger.Print3d.Core
                             {
                                 Attribute = string.Format("CustomAdditionPreMargin_Order{0}", pairs.Key),
                                 Type = CalculationAttributeType.CustomAddition,
+                                Target = CalculationAttributeTarget.File,
                                 Value = pairs.Value * costsSoFar / 100.0,
                                 FileId = file.Id,
                                 FileName = file.FileName,
@@ -408,7 +424,7 @@ namespace AndreasReitberger.Print3d.Core
                         }
 
                         // Get all items where margin calculation is disabled.
-                        List<ICalculationAttribute>? skipMarginCalculation = Rates?.Where(rate => rate.SkipForMargin).ToList();
+                        List<ICalculationAttribute>? skipMarginCalculation = Rates?.Where(rate => rate.SkipForMargin && rate.ApplyPerFile).ToList();
                         skipMarginCalculation?.ForEach((item) =>
                         {
                             costsSoFar -= item.Value;
@@ -421,6 +437,7 @@ namespace AndreasReitberger.Print3d.Core
                             {
                                 Attribute = "Margin",
                                 Type = CalculationAttributeType.Margin,
+                                Target = CalculationAttributeTarget.File,
                                 Value = marginValue,
                                 FileId = file.Id,
                                 FileName = file.FileName,
@@ -450,6 +467,7 @@ namespace AndreasReitberger.Print3d.Core
                                 {
                                     Attribute = $"CustomAdditionPostMargin_Order{pairs.Key}",
                                     Type = CalculationAttributeType.CustomAddition,
+                                    Target = CalculationAttributeTarget.File,
                                     Value = pairs.Value * costsSoFar / 100.0,
                                     FileId = file.Id,
                                     FileName = file.FileName,
@@ -470,6 +488,7 @@ namespace AndreasReitberger.Print3d.Core
                             {
                                 Attribute = "Tax",
                                 Type = CalculationAttributeType.Tax,
+                                Target = CalculationAttributeTarget.File,
                                 Value = taxValue,
                                 FileId = file.Id,
                                 FileName = file.FileName,
@@ -486,6 +505,7 @@ namespace AndreasReitberger.Print3d.Core
                 {
                     Attribute = "HandlingFee",
                     Type = CalculationAttributeType.FixCost,
+                    Target = CalculationAttributeTarget.Project,
                     Value = handlingsFee.Value,
                     FileId = Guid.Empty,
                     FileName = string.Empty,
@@ -499,6 +519,7 @@ namespace AndreasReitberger.Print3d.Core
                         {
                             Attribute = "Margin",
                             Type = CalculationAttributeType.Margin,
+                            Target = CalculationAttributeTarget.Project,
                             Value = marginValue,
                             FileId = Guid.Empty,
                             FileName = string.Empty,
@@ -520,6 +541,7 @@ namespace AndreasReitberger.Print3d.Core
                         LinkedId = ws.Id,
                         Attribute = ws.Name,
                         Type = CalculationAttributeType.Workstep,
+                        Target = CalculationAttributeTarget.Project,
                         Value = totalPerJob,
                     });
                 }
@@ -539,6 +561,7 @@ namespace AndreasReitberger.Print3d.Core
                         LinkedId = item.Id,
                         Attribute = item.Item.Name,
                         Type = CalculationAttributeType.AdditionalItem,
+                        Target = CalculationAttributeTarget.Project,
                         Value = totalPerPiece,
                     });
                 }
@@ -585,6 +608,7 @@ namespace AndreasReitberger.Print3d.Core
                             LinkedId = Guid.Empty,
                             Attribute = add.Name,
                             Type = CalculationAttributeType.ProcedureSpecificAddition,
+                            Target = CalculationAttributeTarget.Project,
                             Value = costs,
                         });
                     }
@@ -604,6 +628,7 @@ namespace AndreasReitberger.Print3d.Core
                     {
                         Attribute = "Tax",
                         Type = CalculationAttributeType.Tax,
+                        Target = CalculationAttributeTarget.Project,
                         Value = taxValue,
                         FileId = Guid.Empty,
                         FileName = string.Empty,

--- a/source/3dPrintCalculatorLibrary.Core/Models/CalculationAttribute.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Models/CalculationAttribute.cs
@@ -27,13 +27,16 @@ namespace AndreasReitberger.Print3d.Core
         string attribute = string.Empty;
 
         [ObservableProperty]
+        CalculationAttributeTarget target;
+
+        [ObservableProperty]
         CalculationAttributeType type;
 
         [ObservableProperty]
         CalculationAttributeItem item = CalculationAttributeItem.Default;
 
         [ObservableProperty]
-        double value;
+        double value = 0;
 
         [ObservableProperty]
         bool isPercentageValue = false;

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Core.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Core.cs
@@ -814,5 +814,71 @@ namespace AndreasReitberger.NUnitTest
                 Assert.Fail(exc.Message);
             }
         }
+
+        [Test]
+        public void MarginCalculationTest()
+        {
+            try
+            {
+                ICalculation3dEnhanced? marginTestCalculation = calculation;
+                marginTestCalculation?.CalculateCosts();
+
+                double margin = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin == 0);
+
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.Margin,
+                    Value = 100, // 100 % margin
+                    IsPercentageValue = true,
+                });
+                marginTestCalculation?.CalculateCosts();
+                margin = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin > 0);
+
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.HandlingFee,
+                    Value = 5, // 5€ fee
+                    IsPercentageValue = false,
+                    ApplyPerFile = false,
+                });
+
+                marginTestCalculation?.CalculateCosts();
+                var margin2 = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin2 > margin);
+
+                calculation.Rates.Clear(); 
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.Margin,
+                    Value = 200, // 200 % margin
+                    IsPercentageValue = true,
+                });
+                marginTestCalculation?.CalculateCosts();
+                var margin3 = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin3 == margin * 2);
+
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.HandlingFee,
+                    Value = 5, // 5€ fee
+                    IsPercentageValue = false,
+                    ApplyPerFile = true,
+                });
+                marginTestCalculation?.CalculateCosts();
+                var margin4 = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin3 == margin * 2);
+
+            }
+            catch (Exception exc)
+            {
+                Assert.Fail(exc.Message);
+            }
+        }
     }
 }

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Realm.cs
@@ -1020,6 +1020,71 @@ namespace AndreasReitberger.NUnitTest
                 Assert.Fail(exc.Message);
             }
         }
-    }
 
+        [Test]
+        public void MarginCalculationTest()
+        {
+            try
+            {
+                Calculation3dEnhanced? marginTestCalculation = calculation;
+                marginTestCalculation?.CalculateCosts();
+
+                double margin = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin == 0);
+
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.Margin,
+                    Value = 100, // 100 % margin
+                    IsPercentageValue = true,
+                });
+                marginTestCalculation?.CalculateCosts();
+                margin = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin > 0);
+
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.HandlingFee,
+                    Value = 5, // 5€ fee
+                    IsPercentageValue = false,
+                    ApplyPerFile = false,
+                });
+
+                marginTestCalculation?.CalculateCosts();
+                var margin2 = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin2 > margin);
+
+                calculation.Rates.Clear();
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.Margin,
+                    Value = 200, // 200 % margin
+                    IsPercentageValue = true,
+                });
+                marginTestCalculation?.CalculateCosts();
+                var margin3 = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin3 == margin * 2);
+
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.HandlingFee,
+                    Value = 5, // 5€ fee
+                    IsPercentageValue = false,
+                    ApplyPerFile = true,
+                });
+                marginTestCalculation?.CalculateCosts();
+                var margin4 = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin3 == margin * 2);
+
+            }
+            catch (Exception exc)
+            {
+                Assert.Fail(exc.Message);
+            }
+        }
+    }
 }

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Sqlite.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.Sqlite.cs
@@ -1439,5 +1439,72 @@ namespace AndreasReitberger.NUnitTest
                 Assert.Fail(exc.Message);
             }
         }
+
+
+        [Test]
+        public void MarginCalculationTest()
+        {
+            try
+            {
+                Calculation3dEnhanced? marginTestCalculation = calculation;
+                marginTestCalculation?.CalculateCosts();
+
+                double margin = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin == 0);
+
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.Margin,
+                    Value = 100, // 100 % margin
+                    IsPercentageValue = true,
+                });
+                marginTestCalculation?.CalculateCosts();
+                margin = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin > 0);
+
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.HandlingFee,
+                    Value = 5, // 5€ fee
+                    IsPercentageValue = false,
+                    ApplyPerFile = false,
+                });
+
+                marginTestCalculation?.CalculateCosts();
+                var margin2 = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin2 > margin);
+
+                calculation.Rates.Clear();
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.Margin,
+                    Value = 200, // 200 % margin
+                    IsPercentageValue = true,
+                });
+                marginTestCalculation?.CalculateCosts();
+                var margin3 = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin3 == margin * 2);
+
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.HandlingFee,
+                    Value = 5, // 5€ fee
+                    IsPercentageValue = false,
+                    ApplyPerFile = true,
+                });
+                marginTestCalculation?.CalculateCosts();
+                var margin4 = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin3 == margin * 2);
+
+            }
+            catch (Exception exc)
+            {
+                Assert.Fail(exc.Message);
+            }
+        }
     }
 }

--- a/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
+++ b/source/3dPrintCalculatorLibrary.NUnitTest/NUnitTest.cs
@@ -834,5 +834,71 @@ namespace AndreasReitberger.NUnitTest
                 Assert.Fail(exc.Message);
             }
         }
+
+        [Test]
+        public void MarginCalculationTest()
+        {
+            try
+            {
+                Calculation3dEnhanced? marginTestCalculation = calculation;
+                marginTestCalculation?.CalculateCosts();
+
+                double margin = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin == 0);
+
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.Margin,
+                    Value = 100, // 100 % margin
+                    IsPercentageValue = true,
+                });
+                marginTestCalculation?.CalculateCosts();
+                margin = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin > 0);
+
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.HandlingFee,
+                    Value = 5, // 5€ fee
+                    IsPercentageValue = false,
+                    ApplyPerFile = false,
+                });
+
+                marginTestCalculation?.CalculateCosts();
+                var margin2 = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin2 > margin);
+
+                calculation.Rates.Clear();
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.Margin,
+                    Value = 200, // 200 % margin
+                    IsPercentageValue = true,
+                });
+                marginTestCalculation?.CalculateCosts();
+                var margin3 = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin3 == margin * 2);
+
+                calculation.Rates.Add(new CalculationAttribute()
+                {
+                    Target = CalculationAttributeTarget.Fee,
+                    Type = CalculationAttributeType.HandlingFee,
+                    Value = 5, // 5€ fee
+                    IsPercentageValue = false,
+                    ApplyPerFile = true,
+                });
+                marginTestCalculation?.CalculateCosts();
+                var margin4 = marginTestCalculation?.CalculatedMargin ?? 0;
+                Assert.That(margin3 == margin * 2);
+
+            }
+            catch (Exception exc)
+            {
+                Assert.Fail(exc.Message);
+            }
+        }
     }
 }

--- a/source/3dPrintCalculatorLibrary.Realm/Models/CalculationAdditions/CalculationAttribute.cs
+++ b/source/3dPrintCalculatorLibrary.Realm/Models/CalculationAdditions/CalculationAttribute.cs
@@ -21,6 +21,13 @@ namespace AndreasReitberger.Print3d.Realm.CalculationAdditions
 
         public string Attribute { get; set; }
 
+        public CalculationAttributeTarget Target
+        {
+            get => (CalculationAttributeTarget)TargetId;
+            set { TargetId = (int)value; }
+        }
+        public int TargetId { get; set; }
+
         public CalculationAttributeType Type
         {
             get => (CalculationAttributeType)TypeId;

--- a/source/3dPrintCalculatorLibrary.SQLite/Models/CalculationAdditions/CalculationAttribute.cs
+++ b/source/3dPrintCalculatorLibrary.SQLite/Models/CalculationAdditions/CalculationAttribute.cs
@@ -34,6 +34,9 @@ namespace AndreasReitberger.Print3d.SQLite.CalculationAdditions
         string attribute;
 
         [ObservableProperty]
+        CalculationAttributeTarget target;
+
+        [ObservableProperty]
         CalculationAttributeType type;
 
         [ObservableProperty]

--- a/source/3dPrintCalculatorLibrary/Enums/CalculationAttributeTarget.cs
+++ b/source/3dPrintCalculatorLibrary/Enums/CalculationAttributeTarget.cs
@@ -5,5 +5,7 @@
         PrintTime,
         Material,
         Fee,
+        File,
+        Project,
     }
 }

--- a/source/3dPrintCalculatorLibrary/Enums/CalculationAttributeType.cs
+++ b/source/3dPrintCalculatorLibrary/Enums/CalculationAttributeType.cs
@@ -13,5 +13,6 @@
         FixCost,
         ProcedureSpecificAddition,
         AdditionalItem,
+        HandlingFee,
     }
 }

--- a/source/3dPrintCalculatorLibrary/Interfaces/ICalculationAttribute.cs
+++ b/source/3dPrintCalculatorLibrary/Interfaces/ICalculationAttribute.cs
@@ -12,6 +12,7 @@ namespace AndreasReitberger.Print3d.Interfaces
         public string FileName { get; set; }
         public Guid LinkedId { get; set; }
         public string Attribute { get; set; }
+        public CalculationAttributeTarget Target { get; set; }
         public CalculationAttributeType Type { get; set; }
         public CalculationAttributeItem Item { get; set; }
         public double Value { get; set; }

--- a/source/3dPrintCalculatorLibrary/Models/CalculationAdditions/CalculationAttribute.cs
+++ b/source/3dPrintCalculatorLibrary/Models/CalculationAdditions/CalculationAttribute.cs
@@ -20,22 +20,25 @@ namespace AndreasReitberger.Print3d.Models.CalculationAdditions
         Guid fileId = Guid.Empty;
 
         [ObservableProperty]
-        string fileName;
+        string fileName = string.Empty;
 
         [ObservableProperty]
         Guid linkedId = Guid.Empty;
 
         [ObservableProperty]
-        string attribute;
+        string attribute = string.Empty;
 
         [ObservableProperty]
         CalculationAttributeType type;
 
         [ObservableProperty]
+        CalculationAttributeTarget target;
+
+        [ObservableProperty]
         CalculationAttributeItem item = CalculationAttributeItem.Default;
 
         [ObservableProperty]
-        double value;
+        double value = 0;
 
         [ObservableProperty]
         bool isPercentageValue = false;


### PR DESCRIPTION
This PR fixes a bug where the `Margin` calculation was wrong if a `HandlingFee` was provided. Also tests have been added to verify the `Margin` calculation.

Fixed #130