### PR TITLE
Added `FileId` property to `PrintFileProcessingInfo`

### DIFF
--- a/source/3dPrintCalculatorLibrary.Core/Interfaces/IPrintFileProcessingInfo.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Interfaces/IPrintFileProcessingInfo.cs
@@ -1,0 +1,33 @@
+﻿using AndreasReitberger.Print3d.Core;
+
+namespace AndreasReitberger.Print3d.Interfaces
+{
+    public interface IPrintFileProcessingInfo
+    {
+        #region Properties
+
+        public Guid Id { get; set; }
+
+        public Guid FileId { get; set; }
+
+        public string FileName { get; set; }
+
+        public string FilePath { get; set; }
+
+        public double Progress { get; set; }
+
+        public bool IsDone { get; set; }
+
+        public double PrintDuration { get; set; }
+
+        public double Volume { get; set; }
+
+        #endregion
+
+        #region Methods
+
+        public File3d ToFile();
+
+        #endregion
+    }
+}

--- a/source/3dPrintCalculatorLibrary.Core/Utilities/PrintFileProcessingInfo.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Utilities/PrintFileProcessingInfo.cs
@@ -1,10 +1,9 @@
-﻿using AndreasReitberger.Print3d.Models;
+﻿using AndreasReitberger.Print3d.Interfaces;
 using CommunityToolkit.Mvvm.ComponentModel;
-using System;
 
-namespace AndreasReitberger.Print3d.Utilities
+namespace AndreasReitberger.Print3d.Core.Utilities
 {
-    public partial class PrintFileProcessingInfo : ObservableObject
+    public partial class PrintFileProcessingInfo : ObservableObject, IPrintFileProcessingInfo
     {
         #region Properties
 

--- a/source/3dPrintCalculatorLibrary.Core/Utilities/UnitFactor.cs
+++ b/source/3dPrintCalculatorLibrary.Core/Utilities/UnitFactor.cs
@@ -4,7 +4,7 @@ namespace AndreasReitberger.Print3d.Core.Utilities
 {
     public static class UnitFactor
     {
-        public static Dictionary<Unit, int> UnitFactors = new()
+        public static  Dictionary<Unit, int> UnitFactors = new()
         {
             { Unit.Gram, 1 },
             { Unit.Kilogram, 1000 },


### PR DESCRIPTION
This PR adds an additional parameter to hold the linked `FileId` of the currently processed file.

Fixed #141